### PR TITLE
검색 공간 변이 정렬 안정화

### DIFF
--- a/optimize/search_spaces.py
+++ b/optimize/search_spaces.py
@@ -99,20 +99,28 @@ def mutate_around(
             width = max(int((spec["max"] - spec["min"]) * scale), int(spec.get("step", 1)))
             low = int(spec["min"])
             high = int(spec["max"])
-            step = int(spec.get("step", 1))
+            step = int(spec.get("step", 1)) or 1
             jitter = rng.integers(-width, width + 1)
             candidate = int(value) + jitter
+            offset = candidate - low
+            candidate = low + int(round(offset / step)) * step
             candidate = max(low, min(high, candidate))
-            candidate = int(round(candidate / step) * step)
             mutated[name] = candidate
         elif dtype == "float":
             span = float(spec["max"] - spec["min"]) * scale
+            low = float(spec["min"])
+            high = float(spec["max"])
             step = float(spec.get("step", 0.0))
             jitter = rng.normal(0.0, span or 1e-6)
             candidate = float(value) + jitter
-            candidate = max(float(spec["min"]), min(float(spec["max"]), candidate))
+            offset = candidate - low
             if step:
-                candidate = round(candidate / step) * step
+                candidate = low + round(offset / step) * step
+            candidate = max(low, min(high, candidate))
+            precision = int(spec.get("precision", 0)) if "precision" in spec else None
+            if precision is not None and precision >= 0:
+                candidate = round(candidate, precision)
+                candidate = max(low, min(high, candidate))
             mutated[name] = float(candidate)
         elif dtype in {"bool", "choice", "str", "string"}:
             if rng.random() < 0.2:

--- a/tests/test_search_spaces.py
+++ b/tests/test_search_spaces.py
@@ -1,6 +1,7 @@
+import numpy as np
 import optuna
 
-from optimize.search_spaces import sample_parameters
+from optimize.search_spaces import mutate_around, sample_parameters
 
 
 def test_sample_parameters_skips_requires_when_condition_false():
@@ -27,3 +28,14 @@ def test_sample_parameters_emits_requires_when_condition_true():
 
     assert params["useStopLoss"] is True
     assert params["stopLookback"] == 6
+
+
+def test_mutate_around_respects_integer_steps():
+    space = {"foo": {"type": "int", "min": 3, "max": 11, "step": 2}}
+    params = {"foo": 7}
+    legal_values = {3, 5, 7, 9, 11}
+
+    rng = np.random.default_rng(123)
+    for _ in range(200):
+        mutated = mutate_around(params, space, scale=0.5, rng=rng)
+        assert mutated["foo"] in legal_values


### PR DESCRIPTION
## 요약
- mutate_around 함수에서 정수/실수 파라미터가 최소값과 스텝에 맞춰 정렬되도록 보정했습니다.
- 실수 파라미터에 대해 precision 옵션을 고려해 범위 내에서 재클램프하도록 했습니다.
- min=3, step=2 조합에 대해 mutate_around가 합법적인 값만 생성하는지 확인하는 테스트를 추가했습니다.

## 테스트
- `pytest tests/test_search_spaces.py`


------
https://chatgpt.com/codex/tasks/task_e_68de4957174083208dd484283270c581