### PR TITLE
LLM 문자열 파라미터 검증 보강

### DIFF
--- a/optimize/llm.py
+++ b/optimize/llm.py
@@ -121,8 +121,10 @@ def _validate_candidate(candidate: Dict[str, object], space: SpaceSpec) -> Optio
                 validated[name] = normalised in {"true", "1", "yes", "on"}
             else:
                 validated[name] = bool(value)
-        elif dtype == "choice":
-            values = list(spec.get("values") or spec.get("options") or [])
+        elif dtype in {"choice", "str", "string"}:
+            values = list(
+                spec.get("values") or spec.get("options") or spec.get("choices") or []
+            )
             if not values:
                 return None
             if value in values:

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,14 @@
+"""`optimize.llm` 모듈에 대한 테스트."""
+from optimize.llm import _validate_candidate
+from optimize.search_spaces import SpaceSpec
+
+
+def test_validate_candidate_accepts_string_choices() -> None:
+    space: SpaceSpec = {
+        "optimizer": {"type": "str", "values": ["Adam", "SGD", "RMSprop"]}
+    }
+    candidate = {"optimizer": " adam "}
+
+    validated = _validate_candidate(candidate, space)
+
+    assert validated == {"optimizer": "Adam"}


### PR DESCRIPTION
## 요약
- LLM 후보 검증 로직에서 문자열/선택형 파라미터를 동일하게 처리하고 values/options/choices 목록을 모두 활용하도록 개선했습니다.
- 문자열 파라미터 후보 검증을 확인하는 단위 테스트를 추가했습니다.

## 테스트
- pytest tests/test_llm.py *(실패: pytest 명령어를 찾을 수 없음)*

------
https://chatgpt.com/codex/tasks/task_e_68de493bae4c8320a0043138201fe7e3