### PR TITLE
월간 타임프레임 리샘플링 보강

### DIFF
--- a/optimize/strategy_model.py
+++ b/optimize/strategy_model.py
@@ -75,16 +75,51 @@ def _timeframe_to_offset(timeframe: str) -> Optional[str]:
     tf = str(timeframe).strip()
     if not tf:
         return None
-    if tf.endswith("m"):
-        return f"{int(tf[:-1])}min"
-    if tf.endswith("h"):
-        return f"{int(tf[:-1])}H"
-    if tf.endswith("D"):
-        return f"{int(tf[:-1])}D"
-    if tf.endswith("W"):
-        return f"{int(tf[:-1])}W"
+
+    def _parse_multiplier(value: str) -> Optional[int]:
+        if not value:
+            return 1
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    tf_upper = tf.upper()
+    tf_lower = tf.lower()
+
+    if tf_upper.endswith("MS"):
+        multiplier = _parse_multiplier(tf[:-2])
+        if multiplier is not None:
+            return f"{multiplier}MS"
+
+    if tf.endswith("M"):
+        multiplier = _parse_multiplier(tf[:-1])
+        if multiplier is not None:
+            return f"{multiplier}MS"
+
+    if tf_lower.endswith("m"):
+        multiplier = _parse_multiplier(tf_lower[:-1])
+        if multiplier is not None:
+            return f"{multiplier}min"
+
+    if tf_lower.endswith("h"):
+        multiplier = _parse_multiplier(tf_lower[:-1])
+        if multiplier is not None:
+            return f"{multiplier}H"
+
+    if tf_lower.endswith("d"):
+        multiplier = _parse_multiplier(tf_lower[:-1])
+        if multiplier is not None:
+            return f"{multiplier}D"
+
+    if tf_lower.endswith("w"):
+        multiplier = _parse_multiplier(tf_lower[:-1])
+        if multiplier is not None:
+            return f"{multiplier}W"
+
     if tf.isdigit():
         return f"{int(tf)}min"
+
     return None
 
 


### PR DESCRIPTION
## 요약
- `_timeframe_to_offset`가 분 단위와 시/일/주 단위를 대소문자 구분 없이 처리하도록 개선하고 월 단위 문자열을 월 시작 기준 오프셋으로 변환하도록 확장
- `_security_series`가 '1M'과 같은 월간 타임프레임을 받을 때 리샘플링을 수행하는지 검증하는 단위 테스트 추가

## 테스트
- `pytest tests/test_strategy_model.py`


------
https://chatgpt.com/codex/tasks/task_e_68de493a24f08320a1425e14e5bd2e6f