### PR TITLE
Optuna SQLite 동시성 완화 및 ProfitFactor 이상치 대응

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ PyYAML>=6.0
 seaborn>=0.13
 pytest>=7.4
 google-genai>=0.3
+SQLAlchemy>=1.4
+tenacity>=8.2


### PR DESCRIPTION
## 요약
- SQLite 스토리지 생성 시 WAL 모드와 타임아웃을 적용하고 병렬 n_jobs를 1로 강제하도록 안전 장치를 추가했습니다.
- Optuna 파라미터 샘플링에 재시도 로직을 입히고 ProfitFactor 이상치 감지 시 페널티와 사용자 속성 기록을 수행합니다.
- tenacity와 SQLAlchemy를 의존성에 추가했습니다.

## 테스트
- `pytest` *(seaborn이 pandas.Series를 가져오지 못해 ImportError 발생)*

------
https://chatgpt.com/codex/tasks/task_e_68df3331dea483209110272bd12ee1f4