### PR TITLE
프로핏 팩터 제너레이터 처리 개선

### DIFF
--- a/optimize/metrics.py
+++ b/optimize/metrics.py
@@ -163,8 +163,16 @@ def sharpe_ratio(returns: pd.Series, risk_free: float = 0.0) -> float:
 
 
 def profit_factor(trades: Iterable[Trade]) -> float:
-    gross_profit = sum(max(trade.profit, 0.0) for trade in trades)
-    gross_loss = sum(min(trade.profit, 0.0) for trade in trades)
+    gross_profit = 0.0
+    gross_loss = 0.0
+
+    for trade in trades:
+        profit = float(trade.profit)
+        if profit > 0:
+            gross_profit += profit
+        else:
+            gross_loss += profit
+
     denominator = max(abs(gross_loss), EPS)
     return float(gross_profit / denominator)
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -17,6 +17,7 @@ from optimize.metrics import (
     evaluate_objective_values,
     max_drawdown,
     normalise_objectives,
+    profit_factor,
     score_metrics,
 )
 from optimize.run import combine_metrics
@@ -65,6 +66,19 @@ def test_aggregate_metrics_basic():
     assert metrics.get("LosslessProfitFactor")
     assert "WeeklyNetProfit" in metrics
     assert "Expectancy" in metrics
+
+
+def test_profit_factor_supports_generators():
+    trades = [
+        Trade(pd.Timestamp("2023-01-01"), pd.Timestamp("2023-01-02"), "long", 1.0, 100, 101, 2.0, 0.02, 0.03, -0.01, 5),
+        Trade(pd.Timestamp("2023-01-03"), pd.Timestamp("2023-01-04"), "short", 1.0, 105, 104, -1.0, -0.01, 0.02, -0.02, 4),
+        Trade(pd.Timestamp("2023-01-05"), pd.Timestamp("2023-01-06"), "long", 1.0, 102, 103, 1.5, 0.015, 0.01, -0.005, 3),
+    ]
+
+    generator = (trade for trade in trades)
+    expected = (2.0 + 1.5) / abs(-1.0)
+
+    assert profit_factor(generator) == pytest.approx(expected)
 
 
 def test_aggregate_metrics_no_losses_is_finite():


### PR DESCRIPTION
## 요약
- profit_factor 계산 시 거래 컬렉션을 한 번만 순회하도록 수정하여 제너레이터 입력을 지원
- 제너레이터 입력에도 기대한 Profit Factor를 반환하는 단위 테스트 추가

## 테스트
- `pytest tests/test_metrics.py -k profit_factor_supports_generators`


------
https://chatgpt.com/codex/tasks/task_e_68df9bd36fc08320bce0d7580eccc78d