### PR TITLE
워크포워드 전체 구간 단일화

### DIFF
--- a/config/backtest.yaml
+++ b/config/backtest.yaml
@@ -13,9 +13,9 @@ datasets:
     end:   2025-09-26
 
 walk_forward:
-  train_bars: 100000
-  test_bars:  30000
-  step:       30000
+  train_bars: 0
+  test_bars:  0
+  step:       0
   min_trades: 12
 
 report:


### PR DESCRIPTION
## 요약
- walk_forward 설정에서 train_bars, test_bars, step 값을 0으로 조정해 전체 데이터셋을 단일 백테스트로 실행하도록 변경했습니다.

## 테스트
- python -m optimize.run --params config/params.yaml --backtest config/backtest.yaml *(심볼 미지정 오류 발생)*

------
https://chatgpt.com/codex/tasks/task_e_68dfa0215f4c83209bad58723a312bbb