### PR TITLE
검색 병렬 파라미터 명시

### DIFF
--- a/config/params.yaml
+++ b/config/params.yaml
@@ -5,6 +5,9 @@ search:
   n_trials: 150
   seed: 42
   top_k: 5
+  n_jobs: 4
+  dataset_jobs: 2
+  dataset_executor: process
   # 기본 병렬: run.py에서 자동 설정(n_jobs=자동)
 
 objective:


### PR DESCRIPTION
## 요약
- search 설정에 Optuna 병렬 worker 수와 데이터셋 병렬 백테스트 파라미터(n_jobs, dataset_jobs, dataset_executor)를 명시해 원하는 병렬도 적용을 보장했습니다.

## 테스트
- `python -m optimize.run --params config/params.yaml --backtest config/backtest.yaml --pick-symbol BINANCE:BTCUSDT --n-trials 1` *(Binance API 네트워크 접근 불가로 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68dfa01e2e7c83209f580e883a351054