### PR TITLE
SQLite 병렬 허용 옵션 추가

### DIFF
--- a/config/params.yaml
+++ b/config/params.yaml
@@ -8,6 +8,7 @@ search:
   n_jobs: 4
   dataset_jobs: 2
   dataset_executor: process
+  allow_sqlite_parallel: false   # true로 설정하면 SQLite에서도 n_jobs 병렬을 유지 (잠금 충돌 가능)
   # 기본 병렬: run.py에서 자동 설정(n_jobs=자동)
 
 # === 엔진/성능 옵션 ===

--- a/docs/optuna_parallel.md
+++ b/docs/optuna_parallel.md
@@ -6,6 +6,9 @@
 
 `n_jobs>1`은 파이썬 스레드 기반이어서 GIL 영향을 받습니다. CPU 바운드 최적화에서는 **프로세스/노드 병렬**이 필수이며, 이를 위해 Optuna 스터디를 외부 RDB에 저장해야 합니다. 2025년 9월 이후 버전부터는 개별 데이터셋 백테스트도 `search.dataset_jobs`와 `search.dataset_executor`(thread/process) 설정으로 병렬화할 수 있으니, 단일 트라이얼이 여러 기간·심볼을 동시에 평가할 때 적극 활용하세요.
 
+- 로컬 SQLite를 반드시 병렬로 사용해야 한다면 `config/params.yaml`에서 `search.allow_sqlite_parallel: true`로 설정하거나 CLI 플래그 `--allow-sqlite-parallel`을 지정할 수 있습니다. Optuna worker 수를 강제로 유지하지만, SQLite 특성상 `database is locked` 재시도가 발생할 수 있으니 모니터링을 권장합니다.
+- YAML에서 해당 옵션을 켜둔 상태라도 특정 실행을 직렬화하고 싶다면 CLI `--force-sqlite-serial`로 즉시 1 worker 제한을 적용할 수 있습니다.
+
 1. 데이터베이스 준비 (예: PostgreSQL)
    ```bash
    createdb pine_optuna

--- a/optimize/run.py
+++ b/optimize/run.py
@@ -1679,6 +1679,15 @@ def optimisation_loop(
         basic_profile_flag = _coerce_bool_or_none(search_cfg.get("use_basic_factors"))
     use_basic_factors = True if basic_profile_flag is None else basic_profile_flag
 
+    allow_sqlite_parallel_flag = _coerce_bool_or_none(
+        search_cfg.get("allow_sqlite_parallel")
+    )
+    allow_sqlite_parallel = (
+        bool(allow_sqlite_parallel_flag)
+        if allow_sqlite_parallel_flag is not None
+        else False
+    )
+
     space = _restrict_to_basic_factors(original_space, enabled=use_basic_factors)
     if use_basic_factors:
         if len(space) != len(original_space):
@@ -1893,6 +1902,7 @@ def optimisation_loop(
             )
             storage_meta["backend"] = "sqlite"
             storage_meta["url"] = storage_url
+            storage_meta["allow_parallel"] = allow_sqlite_parallel
             try:
                 storage_path = make_url(storage_url).database
             except Exception:
@@ -1902,13 +1912,20 @@ def optimisation_loop(
             elif study_storage is not None:
                 storage_meta["path"] = str(study_storage)
             if n_jobs > 1:
-                LOGGER.warning(
-                    "SQLite 스토리지는 동시에 쓰기를 지원하지 않아 Optuna n_jobs를 %d→1로 강제합니다.",
-                    n_jobs,
-                )
-                n_jobs = 1
-                search_cfg["n_jobs"] = n_jobs
-                LOGGER.info("SQLite 스토리지 사용: Optuna 병렬 worker를 1개로 제한합니다.")
+                if allow_sqlite_parallel:
+                    LOGGER.warning(
+                        "SQLite 병렬 허용 옵션이 활성화되었습니다. Optuna worker %d개를 유지하지만 잠금"
+                        " 충돌이 발생할 수 있습니다.",
+                        n_jobs,
+                    )
+                else:
+                    LOGGER.warning(
+                        "SQLite 스토리지는 동시에 쓰기를 지원하지 않아 Optuna n_jobs를 %d→1로 강제합니다.",
+                        n_jobs,
+                    )
+                    n_jobs = 1
+                    search_cfg["n_jobs"] = n_jobs
+                    LOGGER.info("SQLite 스토리지 사용: Optuna 병렬 worker를 1개로 제한합니다.")
         else:
             engine_kwargs = {"pool_pre_ping": True}
             storage = optuna.storages.RDBStorage(
@@ -2637,6 +2654,16 @@ def build_parser() -> argparse.ArgumentParser:
         type=str,
         help="Optuna 스토리지 URL을 읽어올 환경 변수 이름을 덮어씁니다",
     )
+    parser.add_argument(
+        "--allow-sqlite-parallel",
+        action="store_true",
+        help="SQLite 스토리지에서도 Optuna 병렬 worker를 유지합니다 (잠금 충돌 가능)",
+    )
+    parser.add_argument(
+        "--force-sqlite-serial",
+        action="store_true",
+        help="SQLite 스토리지 사용 시 Optuna worker를 1개로 강제합니다",
+    )
     parser.add_argument("--run-tag", type=str, help="Additional suffix for the output directory name")
     parser.add_argument(
         "--run-tag-template",
@@ -2682,6 +2709,7 @@ def _execute_single(
     search_cfg.setdefault("n_jobs", DEFAULT_OPTUNA_JOBS)
     search_cfg.setdefault("dataset_jobs", DEFAULT_DATASET_JOBS)
     search_cfg.setdefault("dataset_executor", "process")
+    search_cfg.setdefault("allow_sqlite_parallel", False)
 
     batch_ctx = getattr(args, "_batch_context", None)
     if batch_ctx:
@@ -2757,6 +2785,12 @@ def _execute_single(
 
     if args.storage_url_env:
         search_cfg["storage_url_env"] = args.storage_url_env
+
+    if getattr(args, "allow_sqlite_parallel", False):
+        search_cfg["allow_sqlite_parallel"] = True
+
+    if getattr(args, "force_sqlite_serial", False):
+        search_cfg["allow_sqlite_parallel"] = False
 
     if args.pruner:
         search_cfg["pruner"] = args.pruner


### PR DESCRIPTION
## 요약
- search 설정에 SQLite 병렬 허용 토글을 추가하고 CLI 플래그로 제어 가능하도록 확장했습니다.
- SQLite 스토리지 사용 시 병렬 허용 여부에 따라 로그와 동작을 분기하여 강제 단일 워커를 해제할 수 있게 했습니다.
- 병렬 사용시 주의사항을 문서화하고 기본 설정 파일에 안내를 추가했습니다.

## 테스트
- python -m compileall optimize/run.py

------
https://chatgpt.com/codex/tasks/task_e_68dfcc0800508320906f4ef6df88b77d