### PR TITLE
SQLite 병렬 워커 유지 및 동시성 보완

### DIFF
--- a/config/params.yaml
+++ b/config/params.yaml
@@ -8,6 +8,7 @@ search:
   n_jobs: 4
   dataset_jobs: 2
   dataset_executor: process
+  allow_sqlite_parallel: false   # true=병렬 허용을 명시, false=병렬 유지하되 잠금 충돌 시 자동 재시도(경고 출력)
   # 기본 병렬: run.py에서 자동 설정(n_jobs=자동)
 
 # === 엔진/성능 옵션 ===

--- a/docs/optuna_parallel.md
+++ b/docs/optuna_parallel.md
@@ -6,6 +6,9 @@
 
 `n_jobs>1`은 파이썬 스레드 기반이어서 GIL 영향을 받습니다. CPU 바운드 최적화에서는 **프로세스/노드 병렬**이 필수이며, 이를 위해 Optuna 스터디를 외부 RDB에 저장해야 합니다. 2025년 9월 이후 버전부터는 개별 데이터셋 백테스트도 `search.dataset_jobs`와 `search.dataset_executor`(thread/process) 설정으로 병렬화할 수 있으니, 단일 트라이얼이 여러 기간·심볼을 동시에 평가할 때 적극 활용하세요.
 
+- 로컬 SQLite에서 병렬을 사용하면 기본적으로 경고만 출력한 뒤 잠금 충돌을 자동 재시도하면서 진행합니다. 명시적으로 병렬 사용을 허용했다고 표시하고 싶다면 `config/params.yaml`의 `search.allow_sqlite_parallel: true` 또는 CLI `--allow-sqlite-parallel`을 지정하세요. SQLite 특성상 `database is locked` 재시도가 발생할 수 있으니 모니터링을 권장합니다.
+- YAML에서 해당 옵션을 켜둔 상태라도 특정 실행을 직렬화하고 싶다면 CLI `--force-sqlite-serial`로 즉시 1 worker 제한을 적용할 수 있습니다.
+
 1. 데이터베이스 준비 (예: PostgreSQL)
    ```bash
    createdb pine_optuna


### PR DESCRIPTION
## 요약
- SQLite 스토리지에서 n_jobs를 1로 강제하던 로직을 제거하고 경고와 자동 재시도로만 처리해 병렬 워커를 유지하도록 변경했습니다.
- Optuna 콜백 로그·CSV·최적 파라미터 스냅샷 작성을 Lock으로 감싸 다중 worker 환경에서도 파일이 깨지지 않도록 보완했습니다.
- CLI `--force-sqlite-serial` 동작과 설정 주석, 병렬 실행 가이드를 최신 동작에 맞춰 갱신했습니다.

## 테스트
- python -m compileall optimize/run.py

------
https://chatgpt.com/codex/tasks/task_e_68dfcc0800508320906f4ef6df88b77d