### PR TITLE
작업 진행상황 로그 및 수익팩터 제약 강화

### DIFF
--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -69,7 +69,7 @@ def test_generate_reports_emits_timeframe_summary(tmp_path: Path) -> None:
             "trial": 0,
             "score": 1.0,
             "params": {"oscLen": 12, "statThreshold": 38.0},
-            "metrics": {"NetProfit": 0.25, "Sortino": 1.8},
+            "metrics": {"NetProfit": 0.25, "Sortino": 1.8, "ProfitFactor": 1.6},
             "datasets": [
                 _make_dataset("BINANCE:ENAUSDT", "1m", "15m", dataset_metrics_a),
                 _make_dataset("BINANCE:ENAUSDT", "3m", "1h", dataset_metrics_b),
@@ -79,7 +79,7 @@ def test_generate_reports_emits_timeframe_summary(tmp_path: Path) -> None:
             "trial": 1,
             "score": 1.2,
             "params": {"oscLen": 14, "statThreshold": 42.0},
-            "metrics": {"NetProfit": 0.3, "Sortino": 1.7},
+            "metrics": {"NetProfit": 0.3, "Sortino": 1.7, "ProfitFactor": 1.4},
             "datasets": [
                 _make_dataset("BINANCE:ENAUSDT", "1m", "15m", dataset_metrics_c),
                 _make_dataset("BINANCE:ENAUSDT", "5m", None, dataset_metrics_d),
@@ -87,20 +87,31 @@ def test_generate_reports_emits_timeframe_summary(tmp_path: Path) -> None:
         },
     ]
 
-    best = {"params": {"oscLen": 12, "statThreshold": 38.0}, "metrics": {"NetProfit": 0.25}, "score": 1.0}
+    best = {
+        "params": {"oscLen": 12, "statThreshold": 38.0},
+        "metrics": {"NetProfit": 0.25, "ProfitFactor": 1.6},
+        "score": 1.0,
+    }
     wf_summary = {}
 
     generate_reports(results, best, wf_summary, ["NetProfit"], tmp_path)
 
+    results_path = tmp_path / "results.csv"
     summary_path = tmp_path / "results_timeframe_summary.csv"
     ranking_path = tmp_path / "results_timeframe_rankings.csv"
 
+    assert results_path.exists()
     assert summary_path.exists()
     assert ranking_path.exists()
 
+    results_df = pd.read_csv(results_path, keep_default_na=False)
     summary_df = pd.read_csv(summary_path, keep_default_na=False)
     ranking_df = pd.read_csv(ranking_path, keep_default_na=False)
 
+    assert results_df.columns[0] == "ProfitFactor"
+    osc_idx = results_df.columns.get_loc("oscLen")
+    stat_idx = results_df.columns.get_loc("statThreshold")
+    assert osc_idx < stat_idx
     assert {"timeframe", "htf_timeframe"}.issubset(summary_df.columns)
     assert (summary_df["timeframe"] == "1m").any()
     assert "Sortino_mean" in ranking_df.columns

--- a/tests/test_run_helpers.py
+++ b/tests/test_run_helpers.py
@@ -6,8 +6,10 @@ import pandas as pd
 import pytest
 
 from optimize.run import (
+    PROFIT_FACTOR_CHECK_LABEL,
     DatasetSpec,
     _apply_study_registry_defaults,
+    _clean_metrics,
     _dataset_total_volume,
     _filter_basic_factor_params,
     _has_sufficient_volume,
@@ -243,3 +245,16 @@ def test_sanitise_storage_meta_masks_password():
     assert masked["url"].startswith("postgresql://postgres:***@127.0.0.1")
     # 원본 딕셔너리는 변경하지 않습니다.
     assert raw["url"].endswith("/optuna")
+
+
+def test_clean_metrics_rounds_profit_factor() -> None:
+    metrics = {"ProfitFactor": 1.98765, "Other": 10}
+    cleaned = _clean_metrics(metrics)
+    assert cleaned["ProfitFactor"] == "1.988"
+    assert cleaned["Other"] == 10
+
+
+def test_clean_metrics_preserves_check_label() -> None:
+    metrics = {"ProfitFactor": PROFIT_FACTOR_CHECK_LABEL}
+    cleaned = _clean_metrics(metrics)
+    assert cleaned["ProfitFactor"] == PROFIT_FACTOR_CHECK_LABEL


### PR DESCRIPTION
## 요약
- 트라이얼 완료 시 "작업 진행상황 ＝＝＝＝＝＝" 로그로 진행률과 핵심 지표를 바로 확인할 수 있도록 Optuna 콜백을 개선했습니다.
- 각 데이터셋과 최종 결과에 대해 최소 트레이드 70건 미만은 학습에서 제외하고, ProfitFactor 50 이상은 "체크 필요"로 표시하며 0.000 단위로 반올림하도록 검증 로직을 보강했습니다.
- ProfitFactor 포맷팅이 기대대로 동작하는지 검증하는 테스트 케이스를 추가했습니다.

## 테스트
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e08cbc75b88320b2c2534c54ffbfdb