### PR TITLE
매직1분VN - Deluxe 모멘텀/플럭스 정합

### DIFF
--- a/config/params.yaml
+++ b/config/params.yaml
@@ -66,7 +66,6 @@ space:
   sellThreshold:        { type: float, min: 20.0, max: 60.0, step: 2.0 }
   dynLen:               { type: int,   min: 10,  max: 60, step: 1 }
   dynMult:              { type: float, min: 0.8, max: 1.8, step: 0.05 }
-  requireMomentumCross: { type: bool }
 
   # --- Exit logic ---
   exitOpposite:   { type: bool }

--- a/optimize/alternative_engine.py
+++ b/optimize/alternative_engine.py
@@ -220,7 +220,7 @@ def _parse_core_settings(
 
     allow_long = _coerce_bool(params.get("allowLongEntry"), True)
     allow_short = _coerce_bool(params.get("allowShortEntry"), True)
-    require_cross = _coerce_bool(params.get("requireMomentumCross"), True)
+    require_cross = True
     exit_opposite = _coerce_bool(params.get("exitOpposite"), True)
 
     if min_trades is not None:
@@ -317,13 +317,14 @@ def _compute_indicators(
     flux_use_ha = _coerce_bool(params.get("useFluxHeikin"), True)
 
     hl2 = (df["high"] + df["low"]) / 2.0
-    bb_basis = _sma(hl2, bb_len)
-    highest = df["high"].rolling(osc_len, min_periods=osc_len).max()
-    lowest = df["low"].rolling(osc_len, min_periods=osc_len).min()
-    channel_mid = (highest + lowest) / 2.0
-    avg_line = (bb_basis + channel_mid) / 2.0
-    atr_primary = _atr(df, osc_len).replace(0.0, np.nan)
-    norm = (df["close"] - avg_line) / atr_primary * 100.0
+    atr_kc = _atr(df, kc_len).replace(0.0, np.nan)
+    kc_basis = _sma(hl2, kc_len)
+    kc_range = atr_kc * kc_mult
+    kc_upper = kc_basis + kc_range
+    kc_lower = kc_basis - kc_range
+    kc_average = (kc_upper + kc_lower) / 2.0
+    midline = (hl2 + kc_average) / 2.0
+    norm = (df["close"] - midline) / atr_kc * 100.0
     momentum = _linreg(norm, osc_len)
     mom_signal = _sma(momentum, sig_len)
 

--- a/optimize/run.py
+++ b/optimize/run.py
@@ -362,7 +362,6 @@ BASIC_FACTOR_KEYS = {
     "sellThreshold",
     "dynLen",
     "dynMult",
-    "requireMomentumCross",
     # Exit logic
     "exitOpposite",
     "useMomFade",

--- a/strategy/strategy.pine
+++ b/strategy/strategy.pine
@@ -98,9 +98,25 @@ float haLow  = math.min(low,  math.min(haOpen, haClose))
 
 float srcClose = dfh ? haClose : close
 
-// --- 플럭스 계산 (단순 기울기 기반) ---
-float fluxRaw = ta.linreg(srcClose - nz(srcClose[1]), dfl, 0)
-float fluxVal = dfSmoothLen > 1 ? ta.sma(fluxRaw, dfSmoothLen) : fluxRaw
+// --- 플럭스 계산 (Deluxe 방식) ---
+float fluxHigh   = dfh ? haHigh : high
+float fluxLow    = dfh ? haLow  : low
+float fluxClose  = srcClose
+float prevClose  = nz(fluxClose[1], fluxClose)
+float upMove     = fluxHigh - nz(fluxHigh[1], fluxHigh)
+float downMove   = nz(fluxLow[1], fluxLow) - fluxLow
+float trRaw      = math.max(fluxHigh - fluxLow, math.max(math.abs(fluxHigh - prevClose), math.abs(fluxLow - prevClose)))
+float tr         = ta.rma(trRaw, dfl)
+float upRma      = ta.rma(math.max(upMove, 0.0), dfl)
+float downRma    = ta.rma(math.max(downMove, 0.0), dfl)
+float trSafe     = tr == 0.0 ? na : tr
+float up         = not na(trSafe) ? upRma / trSafe : 0.0
+float dn         = not na(trSafe) ? downRma / trSafe : 0.0
+float fluxDenom  = up + dn
+float fluxRatio  = fluxDenom != 0 ? (up - dn) / fluxDenom : 0.0
+int   fluxHalf   = math.max(int(math.round(dfl / 2.0)), 1)
+float fluxCore   = ta.rma(fluxRatio, fluxHalf) * 100.0
+float fluxVal    = dfSmoothLen > 1 ? ta.sma(fluxCore, dfSmoothLen) : fluxCore
 
 // --- 스퀴즈 모멘텀 계산 ---
 float bbBasis = ta.sma(close, bbLen)
@@ -108,10 +124,15 @@ float bbDev   = ta.stdev(close, bbLen) * bbMult
 float kcRange = ta.atr(kcLen) * kcMult
 bool squeezeOn = bbDev < kcRange
 
-float highestHigh = ta.highest(high, kcLen)
-float lowestLow   = ta.lowest(low, kcLen)
-float mean        = (highestHigh + lowestLow) / 2.0
-float momentum    = ta.linreg(close - mean, len, 0)
+float hl2         = (high + low) / 2.0
+float kcBasis     = ta.sma(hl2, kcLen)
+float kcUpper     = kcBasis + kcRange
+float kcLower     = kcBasis - kcRange
+float kcAverage   = (kcUpper + kcLower) / 2.0
+float midline     = math.avg(hl2, kcAverage)
+float atrPrimary  = ta.atr(kcLen)
+float norm        = atrPrimary > 0 ? (close - midline) / atrPrimary * 100.0 : 0.0
+float momentum    = ta.linreg(norm, len, 0)
 float momSignal   = ta.sma(momentum, sig)
 
 // --- 페이드 감지 ---

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -397,7 +397,6 @@ def test_time_stop_exit_reason():
         kcMult=1.0,
         fluxLen=2,
         useFluxHeikin=False,
-        requireMomentumCross=False,
         debugForceLong=True,
         startDate=data.index[0].isoformat(),
     )


### PR DESCRIPTION
## 요약
- 스퀴즈 모멘텀을 Deluxe 수식과 동일하게 켈트너 채널 기반으로 재계산하고 히스토그램 표준화를 정비했습니다.
- 방향성 플럭스를 업/다운 모멘텀 비율 기반 산식으로 교체하여 Deluxe 계산과 일치시켰습니다.
- requireMomentumCross를 고정 활성화하고 관련 최적화 파라미터 및 테스트 입력을 정리했습니다.

## 테스트
- `pytest tests/test_strategy_model.py::test_debug_force_long_creates_trade tests/test_metrics.py::test_time_stop_exit_reason`


------
https://chatgpt.com/codex/tasks/task_e_68e17d78c1c483209e2410e6fb49b692