### PR TITLE
스퀴즈 모멘텀 딜럭스 최적화 공간 갱신

### DIFF
--- a/config/params.yaml
+++ b/config/params.yaml
@@ -36,38 +36,34 @@ constraints:
   max_dd_pct: 70        # MaxDD 70% 초과면 패널티
 
 space:
-  # Optimisation search space tuned for the Squeeze Momentum Deluxe strategy.
-  #
-  # Only the core oscillator, signal, volatility channel and fade‑exit
-  # parameters are swept.  All other features (filters, dynamic thresholds,
-  # alternative exits) remain at their default values.  See `optimize/run.py`
-  # for the basic factor key set used by `--basic-factors-only`.
+  # === Squeeze Momentum Deluxe 로직에 맞춘 최적화 공간 ===
 
-  # --- Oscillator & signal lengths ---
-  oscLen:         { type: int,   min: 8,   max: 48, step: 2 }
-  signalLen:      { type: int,   min: 1,   max: 12, step: 1 }
+  # --- 1. 핵심 오실레이터 설정 ---
+  # Deluxe 로직에서는 oscLen이 모멘텀 채널과 스퀴즈 계산 모두에 영향을 줌
+  oscLen:         { type: int,   min: 10,  max: 40, step: 2 }
+  signalLen:      { type: int,   min: 2,   max: 12, step: 1 }
 
-  # --- Volatility channels (Bollinger & Keltner) ---
-  bbLen:          { type: int,   min: 12, max: 30, step: 2 }
-  bbMult:         { type: float, min: 1.5, max: 2.5, step: 0.25 }
-  kcLen:          { type: int,   min: 12, max: 30, step: 2 }
-  kcMult:         { type: float, min: 1.0, max: 2.0, step: 0.2 }
+  # --- 2. 스퀴즈 감지용 KC 채널 ---
+  # Deluxe 로직은 BB 대신 KC와 ATR만으로 스퀴즈를 감지함
+  kcLen:          { type: int,   min: 10,  max: 30, step: 2 }
+  kcMult:         { type: float, min: 1.0, max: 2.5, step: 0.1 }
 
-  # --- Directional flux ---
-  fluxLen:        { type: int,   min: 8,   max: 40, step: 2 }
-  fluxSmoothLen:  { type: int,   min: 1,   max: 10, step: 1 }
+  # --- 3. 방향성 플럭스 ---
+  fluxLen:        { type: int,   min: 10,  max: 40, step: 2 }
+  fluxSmoothLen:  { type: int,   min: 1,   max: 7,  step: 1 }
   useFluxHeikin:  { type: bool }
 
-  # --- Dynamic threshold & momentum gate ---
+  # --- 4. 동적 임계값 및 진입 조건 ---
   useDynamicThresh:     { type: bool }
   useSymThreshold:      { type: bool }
   statThreshold:        { type: float, min: 20.0, max: 80.0, step: 2.0 }
   buyThreshold:         { type: float, min: 20.0, max: 60.0, step: 2.0 }
   sellThreshold:        { type: float, min: 20.0, max: 60.0, step: 2.0 }
-  dynLen:               { type: int,   min: 10,  max: 60, step: 1 }
-  dynMult:              { type: float, min: 0.8, max: 1.8, step: 0.05 }
+  dynLen:               { type: int,   min: 15,  max: 60, step: 5 }
+  dynMult:              { type: float, min: 0.8, max: 2.0, step: 0.1 }
+  requireMomentumCross: { type: bool }
 
-  # --- Exit logic ---
+  # --- 5. 청산 로직 ---
   exitOpposite:   { type: bool }
   useMomFade:     { type: bool }
   momFadeRegLen:  { type: int,   min: 10, max: 40, step: 2 }


### PR DESCRIPTION
## 요약
- params.yaml의 최적화 공간을 스퀴즈 모멘텀 딜럭스 로직 전용 파라미터로 재구성했습니다.
- 불필요해진 Bollinger Band 관련 항목을 제거하고 KC, 플럭스, 동적 임계값, 청산 로직 파라미터 범위를 최신 로직에 맞게 조정했습니다.

## 테스트
- 테스트를 수행하지 않았습니다.


------
https://chatgpt.com/codex/tasks/task_e_68e185b589b08320bf0fef64aa9bb1ab