### PR TITLE
동적·정적 임계값 조합 탐색 제한

### DIFF
--- a/optimize/alternative_engine.py
+++ b/optimize/alternative_engine.py
@@ -359,6 +359,15 @@ def _resolve_thresholds(
     stat_threshold = _coerce_float(params.get("statThreshold"), 38.0)
     buy_threshold = _coerce_float(params.get("buyThreshold"), 36.0)
     sell_threshold = _coerce_float(params.get("sellThreshold"), 36.0)
+    static_active = any(abs(value) > 1e-9 for value in (stat_threshold, buy_threshold, sell_threshold))
+    if not use_dynamic and not static_active:
+        LOGGER.warning(
+            "동적/정적 임계값이 모두 비활성화되어 기본 정적 임계값(38/36)을 적용합니다."
+        )
+        stat_threshold = 38.0
+        buy_threshold = 36.0
+        sell_threshold = 36.0
+        static_active = True
     if use_dynamic:
         dyn_len = max(_coerce_int(params.get("dynLen"), 21), 1)
         dyn_mult = _coerce_float(params.get("dynMult"), 1.1)

--- a/optimize/strategy_model.py
+++ b/optimize/strategy_model.py
@@ -713,6 +713,17 @@ def run_backtest(
     stat_threshold = float_param("statThreshold", 38.0)
     buy_threshold = float_param("buyThreshold", 36.0)
     sell_threshold = float_param("sellThreshold", 36.0)
+    static_threshold_active = any(
+        abs(value) > 1e-9 for value in (stat_threshold, buy_threshold, sell_threshold)
+    )
+    if not use_dynamic_thresh and not static_threshold_active:
+        LOGGER.warning(
+            "동적/정적 임계값이 모두 비활성화되어 기본 정적 임계값(38/36)을 적용합니다."
+        )
+        stat_threshold = 38.0
+        buy_threshold = 36.0
+        sell_threshold = 36.0
+        static_threshold_active = True
     dyn_len = int_param("dynLen", 21, enabled=use_dynamic_thresh)
     dyn_mult = float_param("dynMult", 1.1, enabled=use_dynamic_thresh)
     require_momentum_cross = True

--- a/tests/test_run_helpers.py
+++ b/tests/test_run_helpers.py
@@ -11,6 +11,7 @@ from optimize.run import (
     _apply_study_registry_defaults,
     _clean_metrics,
     _dataset_total_volume,
+    _ensure_threshold_dependencies,
     _filter_basic_factor_params,
     _has_sufficient_volume,
     _group_datasets,
@@ -152,6 +153,34 @@ def test_dataset_total_volume_handles_missing_volume_column():
     total = _dataset_total_volume(dataset)
 
     assert total == 0.0
+
+
+def test_threshold_dependency_enables_dynamic_when_static_absent():
+    params = {
+        "useDynamicThresh": False,
+        "statThreshold": 0.0,
+        "buyThreshold": 0,
+        "sellThreshold": 0,
+    }
+
+    changed = _ensure_threshold_dependencies(params, {})
+
+    assert changed is True
+    assert params["useDynamicThresh"] is True
+
+
+def test_threshold_dependency_respects_forced_dynamic_override():
+    params = {
+        "useDynamicThresh": False,
+        "statThreshold": 0.0,
+        "buyThreshold": 0,
+        "sellThreshold": 0,
+    }
+
+    changed = _ensure_threshold_dependencies(params, {"useDynamicThresh": False})
+
+    assert changed is False
+    assert params["useDynamicThresh"] is False
 
 
 def test_has_sufficient_volume_detects_shortfall():


### PR DESCRIPTION
## 요약
- Optuna 샘플링·시드·LLM 후보에서 동적·정적 임계값이 동시에 비활성화되면 동적 임계값을 강제로 켜도록 안전장치를 추가했습니다.
- 임계 조합 보정 여부를 트라이얼 속성에 기록하고 관련 헬퍼 함수에 대한 단위 테스트를 추가했습니다.

## 테스트
- pytest tests/test_run_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68e20297ddfc8320acf142bf0e11c55b