### PR TITLE
동적 임계값 의존성 검증 개선

### DIFF
--- a/tests/test_run_helpers.py
+++ b/tests/test_run_helpers.py
@@ -163,9 +163,10 @@ def test_threshold_dependency_enables_dynamic_when_static_absent():
         "sellThreshold": 0,
     }
 
-    changed = _ensure_threshold_dependencies(params, {})
+    result = _ensure_threshold_dependencies(params, {})
 
-    assert changed is True
+    assert result.adjusted is True
+    assert result.should_skip is False
     assert params["useDynamicThresh"] is True
 
 
@@ -177,12 +178,11 @@ def test_threshold_dependency_respects_forced_dynamic_override():
         "sellThreshold": 0,
     }
 
-    changed = _ensure_threshold_dependencies(params, {"useDynamicThresh": False})
+    result = _ensure_threshold_dependencies(params, {"useDynamicThresh": False})
 
-    assert changed is False
+    assert result.adjusted is False
+    assert result.should_skip is True
     assert params["useDynamicThresh"] is False
-
-
 def test_has_sufficient_volume_detects_shortfall():
     dataset = _make_dataset("1m", None)
 


### PR DESCRIPTION
## 요약
- 동적/정적 임계값 동시 비활성 조합에 대한 처리 결과를 구조화하여 강제 활성화 또는 스킵 여부를 명확히 반환합니다.
- 시드/LLM 제안 트라이얼과 최적화 목적 함수에서 스킵 신호를 감지해 불필요한 백테스트 실행을 차단합니다.
- 관련 단위 테스트를 새로운 반환 구조에 맞게 갱신하여 스킵 플래그를 검증합니다.

## 테스트
- `pytest tests/test_run_helpers.py`


------
https://chatgpt.com/codex/tasks/task_e_68e20c89a8708320917eaf7e0c21288d