### PR TITLE
래퍼 모델 적용 및 목적 함수 다각화

### DIFF
--- a/config/params.yaml
+++ b/config/params.yaml
@@ -30,6 +30,11 @@ objective:
   # === 기본룰: ProfitFactor 중심 ===
   - name: ProfitFactor
     weight: 1.0
+  - name: Sortino
+    weight: 1.5
+  - name: MaxDD
+    weight: 0.8
+    goal: minimize
 
 constraints:
   min_trades_test: 12   # 테스트 구간에서 최소 거래 수 (없으면 강한 패널티)

--- a/optimize/run.py
+++ b/optimize/run.py
@@ -51,7 +51,7 @@ from optimize.metrics import (
 )
 from optimize.report import generate_reports, write_bank_file, write_trials_dataframe
 from optimize.search_spaces import build_space, grid_choices, mutate_around, sample_parameters
-from optimize.strategy_model import run_backtest
+from optimize.wrapper_strategy_model import run_backtest_wrapped as run_backtest
 from optimize.wf import run_purged_kfold, run_walk_forward
 from optimize.regime import detect_regime_label, summarise_regime_performance
 from optimize.llm import LLMSuggestions, generate_llm_candidates

--- a/optimize/wrapper_strategy_model.py
+++ b/optimize/wrapper_strategy_model.py
@@ -1,33 +1,53 @@
-"""
-Wrapper around the original `run_backtest` function from the
-``optimize.strategy_model`` module.
-
-The purpose of this wrapper is to enforce that various high time
-frame‑related options are disabled when running the backtest.  The
-user indicated that they never use these filters in the Python
-back‑tester and that enabling them only slows the calculation down.
-
-By copying the incoming ``params`` dictionary and overriding the
-relevant keys to ``False``, this wrapper ensures that the underlying
-``run_backtest`` function behaves as if those options were never
-requested.  All other parameters are forwarded unchanged.
-
-To use this wrapper, import ``run_backtest`` from this module
-instead of directly from ``optimize.strategy_model``.
-
-Note: this module depends on the original ``optimize.strategy_model``
-being importable from your environment.  No other functionality from
-``strategy_model`` is modified.
-"""
+"""Utility wrapper for ``optimize.strategy_model.run_backtest``."""
 
 from __future__ import annotations
 
 from typing import Dict, Optional
+
 import pandas as pd
 
-# Import the original run_backtest function.  It will be invoked once
-# we've patched the parameter dictionary.
 from optimize.strategy_model import run_backtest as _original_run_backtest
+
+
+_DISABLE_KEYS = [
+    "useHtfTrend",
+    "useRangeFilter",
+    "useRegimeFilter",
+    "useHmaFilter",
+    "useSlopeFilter",
+    "useDistanceGuard",
+    "useEquitySlopeFilter",
+    "usePivotHtf",
+    "useSqzGate",
+    "useStructureGate",
+]
+
+
+def _patched_params(params: Optional[Dict[str, float | bool | str]]) -> Dict[str, float | bool | str]:
+    patched: Dict[str, float | bool | str] = dict(params or {})
+    for key in _DISABLE_KEYS:
+        patched[key] = False
+    return patched
+
+
+def run_backtest_wrapped(
+    df: pd.DataFrame,
+    params: Dict[str, float | bool | str],
+    fees: Dict[str, float],
+    risk: Dict[str, float | bool],
+    htf_df: Optional[pd.DataFrame] = None,
+    min_trades: Optional[int] = None,
+) -> Dict[str, float]:
+    """Run the original backtest after forcing specific HTF options off."""
+
+    return _original_run_backtest(
+        df,
+        _patched_params(params),
+        fees,
+        risk,
+        htf_df=htf_df,
+        min_trades=min_trades,
+    )
 
 
 def run_backtest(
@@ -38,72 +58,11 @@ def run_backtest(
     htf_df: Optional[pd.DataFrame] = None,
     min_trades: Optional[int] = None,
 ) -> Dict[str, float]:
-    """Run a backtest with certain high time‑frame options forcibly disabled.
+    """Compatibility alias that calls :func:`run_backtest_wrapped`."""
 
-    Parameters
-    ----------
-    df : pd.DataFrame
-        The OHLCV data set to backtest.  This must already have a
-        DatetimeIndex and the columns ``open``, ``high``, ``low``,
-        ``close`` and ``volume``.
-    params : Dict[str, float | bool | str]
-        The parameter dictionary.  This wrapper will create a copy of
-        the dictionary and set several HTF‑related keys to ``False``.
-    fees : Dict[str, float]
-        Commission and slippage settings.
-    risk : Dict[str, float | bool]
-        Risk management parameters such as leverage and initial capital.
-    htf_df : Optional[pd.DataFrame], default ``None``
-        Optional high time frame data.  This is forwarded unchanged.
-    min_trades : Optional[int], default ``None``
-        Minimum trades requirement.  Forwarded unchanged.
-
-    Returns
-    -------
-    Dict[str, float]
-        A dictionary of aggregated performance metrics, as returned
-        by the original ``run_backtest``.
-
-    This wrapper does not modify the underlying implementation of
-    ``run_backtest``.  It simply ensures that certain high
-    time‑frame features (trend, range, regime, HMA filter, slope
-    filter, distance guard, equity slope filter, pivot HTF, squeeze
-    gate and structure gate) are disabled before delegating to the
-    original function.
-    """
-    # Create a copy of the params dictionary to avoid mutating the
-    # caller's object.  If ``params`` is ``None`` it would be
-    # unexpected, but we guard against it by starting with an empty
-    # dictionary.
-    patched_params: Dict[str, float | bool | str] = dict(params or {})
-
-    # Keys corresponding to high‑time‑frame or complex filters that
-    # should be disabled for the Python back‑tester.  See
-    # ``strategy_model.py`` for the full list of available options.
-    disable_keys = [
-        "useHtfTrend",
-        "useRangeFilter",
-        "useRegimeFilter",
-        "useHmaFilter",
-        "useSlopeFilter",
-        "useDistanceGuard",
-        "useEquitySlopeFilter",
-        "usePivotHtf",
-        "useSqzGate",
-        "useStructureGate",
-    ]
-
-    # Set each of the above keys to False.  If the key does not
-    # already exist, it will simply be inserted with a False value.
-    for key in disable_keys:
-        patched_params[key] = False
-
-    # Delegate to the original backtest function with the patched
-    # parameter dictionary.  All other arguments are forwarded
-    # unchanged.
-    return _original_run_backtest(
+    return run_backtest_wrapped(
         df,
-        patched_params,
+        params,
         fees,
         risk,
         htf_df=htf_df,


### PR DESCRIPTION
## 요약
- optimize.run 모듈에서 wrapper_strategy_model의 래퍼 함수를 사용하도록 변경했습니다.
- wrapper_strategy_model.py를 정리하고 원본 백테스트 함수에 필요한 옵션 강제 비활성화를 적용했습니다.
- params.yaml의 objective에 Sortino와 MaxDD 항목을 추가해 수익/위험 균형 평가가 가능하도록 했습니다.

## 테스트
- pytest tests/test_run_helpers.py *(ImportError: optimize.metrics 모듈에서 EPS 기호를 찾을 수 없음)*

------
https://chatgpt.com/codex/tasks/task_e_68e2230e548c8320a2fdc7872e752834