### PR TITLE
쑨모멘텀 로직과 탐색 공간 동기화

### DIFF
--- a/optimize/search_spaces.py
+++ b/optimize/search_spaces.py
@@ -138,3 +138,105 @@ def mutate_around(
         else:
             continue
     return mutated
+
+
+def get_search_spaces() -> List[Dict[str, object]]:
+    """Optuna 탐색 공간 프리셋을 반환합니다."""
+
+    spaces: List[Dict[str, object]] = [
+        {
+            "key": "sun_deluxe_core",
+            "label": "쑨모멘텀 디럭스 – 핵심 파라미터",
+            "space": build_space(
+                {
+                    "oscLen": {"type": "int", "min": 10, "max": 40, "step": 2},
+                    "signalLen": {"type": "int", "min": 2, "max": 12, "step": 1},
+                    "kcLen": {"type": "int", "min": 10, "max": 30, "step": 2},
+                    "kcMult": {"type": "float", "min": 1.0, "max": 2.5, "step": 0.1},
+                    "fluxLen": {"type": "int", "min": 10, "max": 40, "step": 2},
+                    "fluxSmoothLen": {"type": "int", "min": 1, "max": 7, "step": 1},
+                    "useFluxHeikin": {"type": "bool"},
+                    "useDynamicThresh": {"type": "bool"},
+                    "useSymThreshold": {
+                        "type": "bool",
+                        "requires": {"name": "useDynamicThresh", "equals": False},
+                    },
+                    "statThreshold": {
+                        "type": "float",
+                        "min": 20.0,
+                        "max": 80.0,
+                        "step": 2.0,
+                        "requires": {"name": "useDynamicThresh", "equals": False},
+                    },
+                    "buyThreshold": {
+                        "type": "float",
+                        "min": 20.0,
+                        "max": 60.0,
+                        "step": 2.0,
+                        "requires": {"name": "useDynamicThresh", "equals": False},
+                    },
+                    "sellThreshold": {
+                        "type": "float",
+                        "min": 20.0,
+                        "max": 60.0,
+                        "step": 2.0,
+                        "requires": {"name": "useDynamicThresh", "equals": False},
+                    },
+                    "dynLen": {
+                        "type": "int",
+                        "min": 15,
+                        "max": 60,
+                        "step": 5,
+                        "requires": {"name": "useDynamicThresh", "equals": True},
+                    },
+                    "dynMult": {
+                        "type": "float",
+                        "min": 0.8,
+                        "max": 2.0,
+                        "step": 0.1,
+                        "requires": {"name": "useDynamicThresh", "equals": True},
+                    },
+                    "requireMomentumCross": {"type": "bool"},
+                    "exitOpposite": {"type": "bool"},
+                    "useMomFade": {"type": "bool"},
+                    "momFadeRegLen": {
+                        "type": "int",
+                        "min": 10,
+                        "max": 40,
+                        "step": 2,
+                        "requires": "useMomFade",
+                    },
+                    "momFadeBbLen": {
+                        "type": "int",
+                        "min": 10,
+                        "max": 40,
+                        "step": 2,
+                        "requires": "useMomFade",
+                    },
+                    "momFadeKcLen": {
+                        "type": "int",
+                        "min": 10,
+                        "max": 40,
+                        "step": 2,
+                        "requires": "useMomFade",
+                    },
+                    "momFadeBbMult": {
+                        "type": "float",
+                        "min": 1.5,
+                        "max": 3.0,
+                        "step": 0.25,
+                        "requires": "useMomFade",
+                    },
+                    "momFadeKcMult": {
+                        "type": "float",
+                        "min": 1.0,
+                        "max": 3.0,
+                        "step": 0.25,
+                        "requires": "useMomFade",
+                    },
+                }
+            ),
+        }
+    ]
+
+    return spaces


### PR DESCRIPTION
## 요약
- 모멘텀 정규화와 방향성 플럭스 계산을 쑨모멘텀 수식에 맞춰 재구성했습니다.
- Optuna 탐색 공간 프리셋을 쑨모멘텀 설정과 동일한 범위로 교체했습니다.

## 테스트
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3d7fb9cbc8320abb4ebff1beb4300