### PR TITLE
HTF 의존성 제거 및 LTF 전용 동작 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ pip install -r requirements.txt
    on/off before a run and enable Top-K walk-forward re-ranking via `search.top_k`.
 3. Configure the sweep universe in `config/backtest.yaml`. By default it contains
   nine Binance USDT perpetual pairs (ENA, ETH, BTC, SOL, **XPLA**, **ASTER**, DOGE,
-  XRP, SUI) with lower timeframes 1m/3m/5m, higher timeframes 15m/1h, and a single
-  2024-01-01 → 2025-09-25 창. The optimiser now treats the LTF/HTF selections as
-  categorical parameters, so each Optuna trial chooses one combination while the
-  reports highlight which pairing delivers the strongest Sortino/Profit Factor.
+  XRP, SUI) with lower timeframes 1m/3m/5m and a single 2024-01-01 → 2025-09-25 창.
+  Higher-timeframe 확정 신호는 전부 비활성화되어 현재는 LTF 단일 조합만 탐색합니다.
+  따라서 각 Optuna 트라이얼은 하나의 LTF를 선택하며, 리포트는 어떤 하위 봉이 가장
+  나은 Sortino/Profit Factor 를 제공하는지에 집중합니다.
   The `symbol_aliases` mapping lets you keep the newly-listed ticker names you
   prefer (`XPLUSDT`, `ASTERUSDT`) while the optimiser automatically fetches data
   using Binance's current instruments (`XPLAUSDT`, `ASTRUSDT`).
@@ -69,12 +69,12 @@ pip install -r requirements.txt
   ```
 
    The interactive mode lets you pick the symbol, evaluation window, leverage,
-   position size, and the boolean filters (HTF sync, ATR trail, pivot stops,
+   position size, and the boolean filters (ATR trail, pivot stops,
    breakeven, etc.) from the terminal. Command-line overrides are also
    available:
 
-   - `--symbol`, `--timeframe`, `--htf`, `--start`, `--end`
-   - `--timeframe-grid 1m@15m,3m@1h` 으로 여러 LTF/HTF 조합을 일괄 실행 (필요 시 `--study-template`, `--run-tag-template` 으로 이름 규칙 지정)
+   - `--symbol`, `--timeframe`, `--start`, `--end`
+   - `--timeframe-grid 1m,3m,5m` 으로 여러 LTF 조합을 일괄 실행 (필요 시 `--study-template`, `--run-tag-template` 으로 이름 규칙 지정)
    - `--leverage`, `--qty-pct`
    - `--n-trials`
   - `--n-jobs 4` 처럼 Optuna 병렬 worker 수를 지정해 멀티코어를 활용할 수 있습니다. 기본값은 PostgreSQL 스토리지일 때 CPU 코어 수 전체를 활용하도록 자동 설정됩니다.
@@ -82,7 +82,7 @@ pip install -r requirements.txt
    - `--top-k 10` to re-rank the best Optuna trials by walk-forward out-of-sample
      performance.
   - `--storage-url-env OPTUNA_STORAGE` 로 YAML 설정 없이도 Optuna 스토리지 환경 변수를 바꿔 외부 RDB를 가리킬 수 있습니다.
-  - 실행이 한 번 끝나면 `studies/<심볼>_<ltf>_<htf>/storage.json` 파일에 사용된 스토리지 백엔드가 기록됩니다. 이후에는 YAML에 따로 URL을 넣지 않아도 동일한 심볼/타임프레임 조합으로 실행할 때 자동으로 PostgreSQL 설정을 불러옵니다.
+  - 실행이 한 번 끝나면 `studies/<심볼>_<ltf>/storage.json` 파일에 사용된 스토리지 백엔드가 기록됩니다. 이후에는 YAML에 따로 URL을 넣지 않아도 동일한 심볼/타임프레임 조합으로 실행할 때 자동으로 PostgreSQL 설정을 불러옵니다.
 
   Outputs are written to `reports/` (`results.csv`, `results_datasets.csv`,
   `results_timeframe_summary.csv`, `results_timeframe_rankings.csv`, `best.json`,
@@ -90,12 +90,12 @@ pip install -r requirements.txt
   `best.yaml`, `trials_final.csv`). These files are flushed after **every** trial so
   you still keep the trail even if the run is interrupted. The `results_datasets.csv`
   file is especially useful for answering
-  “어떤 LTF/HTF 조합이 가장 좋은가요?” because every dataset row lists the symbol,
-  LTF, HTF, and the full metric set (Net Profit, Sortino, Profit Factor, MaxDD,
+  “어떤 LTF가 가장 좋은가요?” because every dataset row lists the symbol,
+  LTF, and the full metric set (Net Profit, Sortino, Profit Factor, MaxDD,
   Win Rate, Weekly Net Profit, 등). The automatically generated
   `results_timeframe_summary.csv`/`results_timeframe_rankings.csv` pair then pivots
   those rows into 평균·중앙값 테이블과 정렬 리스트 so you can immediately compare
-  1m/3m/5m vs 15m/60m 조합. The `best.json` payload also includes the Top-K candidate
+  1m/3m/5m 성능 차이를 확인할 수 있습니다. The `best.json` payload also includes the Top-K candidate
   summary with their walk-forward scores.
 
 ### Quick-start helper
@@ -168,11 +168,11 @@ python -m optimize.run --params config/params.yaml --backtest config/backtest.ya
 
 ## 병렬/대규모 최적화
 
-- `config/params.yaml` 의 `search.study_name` 으로 스터디 이름을 고정하면 여러 프로세스가 같은 스터디를 공유할 수 있습니다. 이름을 지정하지 않으면 자동으로 `심볼_LTF_HTF_해시` 형태가 생성돼 배치 실행 시 충돌을 방지합니다.
+- `config/params.yaml` 의 `search.study_name` 으로 스터디 이름을 고정하면 여러 프로세스가 같은 스터디를 공유할 수 있습니다. 이름을 지정하지 않으면 자동으로 `심볼_LTF_해시` 형태가 생성돼 배치 실행 시 충돌을 방지합니다.
 - `search.storage_url_env`(기본값 `OPTUNA_STORAGE`), CLI `--storage-url-env`, `--storage-url` 로 RDB 접속 정보를 지정하면 Optuna가 프로세스/노드 병렬을 지원합니다. 환경 변수가 없으면 자동으로 `studies/` 아래 SQLite 파일을 사용합니다.
 - 스터디를 처음 생성하면 `studies/<slug>/storage.json` 포인터가 같이 생성됩니다. 여기에는 최근 실행 시 사용된 스토리지 URL(비밀번호 등 민감 정보는 마스킹), 환경 변수 이름, 풀 설정이 기록되며, 다음 실행에서 `search.storage_url`/`storage_url_env` 값이 비어 있을 경우 자동으로 재사용됩니다.
 - CLI `--study-name`/`--storage-url` 플래그는 YAML 설정을 일시적으로 덮어쓰는 용도로 사용할 수 있습니다.
-- `--timeframe-grid` 를 사용하면 여러 타임프레임 조합을 한 번에 실행하면서 각 조합마다 독립된 리포트/스터디가 생성되며, 필요 시 `--study-template`, `--run-tag-template` 로 이름 규칙을 조정할 수 있습니다.
+- `--timeframe-grid` 를 사용하면 여러 LTF 조합을 한 번에 실행하면서 각 조합마다 독립된 리포트/스터디가 생성되며, 필요 시 `--study-template`, `--run-tag-template` 로 이름 규칙을 조정할 수 있습니다.
 - 기본 프로필은 다목표(`NetProfit`, `Sortino`, `ProfitFactor`, `MaxDD`) 최적화를 활성화하고 Optuna NSGA-II 샘플러(population 120, crossover 0.9)를 자동 선택합니다. 파라미터는 `search.nsga_params` 로 세부 조정 가능합니다.
 - 타임프레임 조합별 1,000회 실행, Dask/Ray 연동 방법 등 자세한 절차는 [`docs/optuna_parallel.md`](docs/optuna_parallel.md) 를 참고하세요.
 
@@ -195,6 +195,6 @@ pytest
   weekly net profit, expectancy, RR, average MFE/MAE, and average holding period. The
   optimiser combines weighted objectives with penalties for breaching the risk gates and
   can optionally re-score the top trials by walk-forward OOS mean.
-- Optimisation state is stored in `studies/<symbol>_<ltf>_<htf>.db` (SQLite + heartbeat)
+- Optimisation state is stored in `studies/<symbol>_<ltf>.db` (SQLite + heartbeat)
   so 중단 후 재실행 시 자동으로 이어달리기(warm start)가 됩니다. JSONL/YAML 로그는
   최적화 도중 예기치 못한 종료가 발생해도 남도록 `trials/` 폴더에 즉시 기록됩니다.

--- a/optimize/metrics.py
+++ b/optimize/metrics.py
@@ -165,8 +165,14 @@ def apply_lossless_anomaly(
         flags.append(flag)
     target["AnomalyFlags"] = flags
 
-    # Indicate that the profit factor is beyond a meaningful finite range.
-    target["ProfitFactor"] = "overfactor"
+    # Preserve the original profit factor for reference and reset the
+    # public-facing value to a finite placeholder.  Downstream reports
+    # surface ``LosslessProfitFactor`` so 사용자는 손실이 없는 구간임을 알 수 있고,
+    # 기본 ``ProfitFactor`` 열은 항상 수치형(0)으로 유지됩니다.
+    original_pf = target.get("ProfitFactor", "overfactor")
+    target["LosslessProfitFactorValue"] = original_pf
+    target["LosslessProfitFactor"] = True
+    target["ProfitFactor"] = 0.0
 
     return flag, trades_val, wins_val, abs(gross_loss_val), threshold_val
 

--- a/optimize/run.py
+++ b/optimize/run.py
@@ -63,6 +63,9 @@ from tenacity import (
     wait_exponential,
 )
 
+
+HTF_ENABLED = False
+
 def fetch_top_usdt_perp_symbols(
     limit: int = 50,
     exclude_symbols: Optional[Sequence[str]] = None,
@@ -483,7 +486,7 @@ def _slugify_symbol(symbol: str) -> str:
 
 def _slugify_timeframe(timeframe: Optional[str]) -> str:
     if not timeframe:
-        return "nohtf"
+        return ""
     return str(timeframe).replace("/", "_").replace(" ", "")
 
 
@@ -591,18 +594,19 @@ def _build_run_tag(
         params_cfg.get("timeframe")
         or (datasets[0].timeframe if datasets else "multi")
     )
-    htf = (
-        params_cfg.get("htf_timeframe")
-        or params_cfg.get("htf")
-        or (datasets[0].htf_timeframe if datasets and datasets[0].htf_timeframe else "nohtf")
-    )
-    if not htf:
-        htf = "nohtf"
+    htf = None
+    if HTF_ENABLED:
+        htf = (
+            params_cfg.get("htf_timeframe")
+            or params_cfg.get("htf")
+            or (datasets[0].htf_timeframe if datasets and datasets[0].htf_timeframe else "nohtf")
+        )
+        if not htf:
+            htf = "nohtf"
     symbol_slug = _slugify_symbol(str(symbol))
     timeframe_slug = str(timeframe).replace("/", "_")
-    htf_slug = str(htf).replace("/", "_")
     timestamp = datetime.now(UTC).strftime("%Y%m%d-%H%M")
-    parts = [timestamp, symbol_slug, timeframe_slug, htf_slug]
+    parts = [timestamp, symbol_slug, timeframe_slug]
     if run_tag:
         parts.append(run_tag)
     return timestamp, symbol_slug, timeframe_slug, "_".join(filter(None, parts))
@@ -845,8 +849,6 @@ def _resolve_output_directory(
     run_tag: Optional[str],
 ) -> Tuple[Path, Dict[str, str]]:
     ts, symbol_slug, timeframe_slug, tag = _build_run_tag(datasets, params_cfg, run_tag)
-    htf_value = _extract_primary_htf(params_cfg, datasets)
-    htf_slug = _slugify_timeframe(htf_value)
     if base is None:
         root = DEFAULT_REPORT_ROOT
         output = root / tag
@@ -854,13 +856,15 @@ def _resolve_output_directory(
         output = base
     output = _next_available_dir(output)
     output.mkdir(parents=True, exist_ok=False)
-    return output, {
+    manifest = {
         "timestamp": ts,
         "symbol": symbol_slug,
         "timeframe": timeframe_slug,
-        "htf_timeframe": htf_slug,
         "tag": tag,
     }
+    if HTF_ENABLED:
+        manifest["htf_timeframe"] = _slugify_timeframe(_extract_primary_htf(params_cfg, datasets))
+    return output, manifest
 
 
 def _write_manifest(
@@ -880,26 +884,25 @@ def _load_json(path: Path) -> Dict[str, object]:
         return {}
 
 
-def _parse_timeframe_grid(raw: Optional[str]) -> List[Tuple[str, Optional[str]]]:
+def _parse_timeframe_grid(raw: Optional[str]) -> List[str]:
     if not raw:
         return []
-    combos: List[Tuple[str, Optional[str]]] = []
+    combos: List[str] = []
     text = str(raw).replace("\n", ",").replace(";", ",")
     for token in text.split(","):
         candidate = token.strip()
         if not candidate:
             continue
         if "@" in candidate:
-            ltf, htf = candidate.split("@", 1)
+            ltf, _ = candidate.split("@", 1)
         elif ":" in candidate:
-            ltf, htf = candidate.split(":", 1)
+            ltf, _ = candidate.split(":", 1)
         else:
-            ltf, htf = candidate, None
+            ltf = candidate
         ltf = ltf.strip()
-        htf = htf.strip() if htf is not None else None
         if not ltf:
             continue
-        combos.append((ltf, htf or None))
+        combos.append(ltf)
     return combos
 
 
@@ -926,11 +929,7 @@ def _resolve_study_storage(
 ) -> Optional[Path]:
     STUDY_ROOT.mkdir(parents=True, exist_ok=True)
     _, symbol_slug, timeframe_slug, _ = _build_run_tag(datasets, params_cfg, None)
-    htf = params_cfg.get("htf_timeframe") or (
-        datasets[0].htf_timeframe if datasets and datasets[0].htf_timeframe else "nohtf"
-    )
-    htf_slug = str(htf or "nohtf").replace("/", "_")
-    return STUDY_ROOT / f"{symbol_slug}_{timeframe_slug}_{htf_slug}.db"
+    return STUDY_ROOT / f"{symbol_slug}_{timeframe_slug}.db"
 
 
 def _study_registry_dir(storage_path: Path) -> Path:
@@ -1000,6 +999,8 @@ def _extract_primary_htf(
     params_cfg: Dict[str, object],
     datasets: Sequence["DatasetSpec"],
 ) -> Optional[str]:
+    if not HTF_ENABLED:
+        return None
     raw = params_cfg.get("htf_timeframes")
     if isinstance(raw, (list, tuple)) and len(raw) == 1:
         return str(raw[0])
@@ -1017,10 +1018,8 @@ def _default_study_name(
     space_hash: Optional[str] = None,
 ) -> str:
     _, symbol_slug, timeframe_slug, _ = _build_run_tag(datasets, params_cfg, None)
-    htf = _extract_primary_htf(params_cfg, datasets)
-    htf_slug = _slugify_timeframe(htf)
     suffix = f"_{space_hash[:6]}" if space_hash else ""
-    return f"{symbol_slug}_{timeframe_slug}_{htf_slug}{suffix}"
+    return f"{symbol_slug}_{timeframe_slug}{suffix}"
 
 
 def _discover_bank_path(
@@ -1548,15 +1547,6 @@ def prepare_datasets(
             if not ltf_candidates:
                 raise ValueError(f"{symbol_value} 데이터셋에 최소 하나의 ltf/timeframe 이 필요합니다.")
 
-            htf_candidates = _to_list(
-                entry.get("htf")
-                or entry.get("htfs")
-                or entry.get("htf_timeframes")
-                or entry.get("htf_timeframe")
-            )
-            if not htf_candidates:
-                htf_candidates = [None]
-
             start_value = entry.get("start") or entry.get("from") or base_period.get("from")
             end_value = entry.get("end") or entry.get("to") or base_period.get("to")
             if not start_value or not end_value:
@@ -1569,34 +1559,26 @@ def prepare_datasets(
             )
             for timeframe in ltf_candidates:
                 timeframe_text = str(timeframe)
-                for htf_tf in htf_candidates or [None]:
-                    htf_text = str(htf_tf) if htf_tf else None
-                    LOGGER.info(
-                        "Preparing dataset %s %s (HTF %s) %s→%s",
-                        symbol_log,
-                        timeframe_text,
-                        htf_text or "-",
-                        start,
-                        end,
+                LOGGER.info(
+                    "Preparing dataset %s %s %s→%s (LTF only)",
+                    symbol_log,
+                    timeframe_text,
+                    start,
+                    end,
+                )
+                df = cache.get(source_symbol, timeframe_text, start, end)
+                datasets.append(
+                    DatasetSpec(
+                        symbol=display_symbol,
+                        timeframe=timeframe_text,
+                        start=start,
+                        end=end,
+                        df=df,
+                        htf=None,
+                        htf_timeframe=None,
+                        source_symbol=source_symbol,
                     )
-                    df = cache.get(source_symbol, timeframe_text, start, end)
-                    htf_df = (
-                        cache.get(source_symbol, htf_text, start, end, allow_partial=True)
-                        if htf_text
-                        else None
-                    )
-                    datasets.append(
-                        DatasetSpec(
-                            symbol=display_symbol,
-                            timeframe=timeframe_text,
-                            start=start,
-                            end=end,
-                            df=df,
-                            htf=htf_df,
-                            htf_timeframe=htf_text,
-                            source_symbol=source_symbol,
-                        )
-                    )
+                )
         if not datasets:
             raise ValueError("backtest.datasets 설정에서 어떤 데이터셋도 생성되지 않았습니다.")
         return datasets
@@ -1625,21 +1607,11 @@ def prepare_datasets(
             "Backtest configuration must specify symbol(s), timeframe(s), and at least one period with 'from'/'to' dates."
         )
 
-    htf_candidates = _to_list(params_cfg.get("htf_timeframes"))
-    if not htf_candidates:
-        htf_candidates = _to_list(params_cfg.get("htf_timeframe"))
-    if not htf_candidates:
-        htf_candidates = _to_list(backtest_cfg.get("htf_timeframes"))
-    if not htf_candidates:
-        htf_candidates = _to_list(backtest_cfg.get("htf_timeframe"))
-    if not htf_candidates:
-        htf_candidates = [None]
-
     symbol_pairs = [_resolve_symbol_entry(symbol, alias_map) for symbol in symbols]
 
     datasets: List[DatasetSpec] = []
-    for (display_symbol, source_symbol), timeframe, period, htf_tf in product(
-        symbol_pairs, timeframes, periods, htf_candidates
+    for (display_symbol, source_symbol), timeframe, period in product(
+        symbol_pairs, timeframes, periods
     ):
         start = str(period["from"])
         end = str(period["to"])
@@ -1647,19 +1619,13 @@ def prepare_datasets(
             display_symbol if display_symbol == source_symbol else f"{display_symbol}→{source_symbol}"
         )
         LOGGER.info(
-            "Preparing dataset %s %s (HTF %s) %s→%s",
+            "Preparing dataset %s %s %s→%s (LTF only)",
             symbol_log,
             timeframe,
-            htf_tf or "-",
             start,
             end,
         )
         df = cache.get(source_symbol, timeframe, start, end)
-        htf = (
-            cache.get(source_symbol, str(htf_tf), start, end, allow_partial=True)
-            if htf_tf
-            else None
-        )
         datasets.append(
             DatasetSpec(
                 symbol=display_symbol,
@@ -1667,8 +1633,8 @@ def prepare_datasets(
                 start=start,
                 end=end,
                 df=df,
-                htf=htf,
-                htf_timeframe=str(htf_tf) if htf_tf else None,
+                htf=None,
+                htf_timeframe=None,
                 source_symbol=source_symbol,
             )
         )
@@ -3159,11 +3125,10 @@ def build_parser() -> argparse.ArgumentParser:
         help="직접 심볼 지정 (예: BINANCE:ETHUSDT). 지정 시 top50 무시",
     )
     parser.add_argument("--timeframe", type=str, help="Override lower timeframe")
-    parser.add_argument("--htf", type=str, help="Override higher timeframe for confirmations")
     parser.add_argument(
         "--timeframe-grid",
         type=str,
-        help="Comma/semicolon separated LTF@HTF 조합을 일괄 실행 (예: '1m@15m,1m@1h')",
+        help="쉼표/세미콜론으로 구분된 다중 LTF 목록을 일괄 실행 (예: '1m,3m,5m')",
     )
     parser.add_argument("--start", type=str, help="Override backtest start date (ISO8601)")
     parser.add_argument("--end", type=str, help="Override backtest end date (ISO8601)")
@@ -3229,7 +3194,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--study-template",
         type=str,
-        help="--timeframe-grid 사용 시 스터디 이름 템플릿 (예: '{symbol_slug}_{ltf_slug}_{htf_slug}')",
+        help="--timeframe-grid 사용 시 스터디 이름 템플릿 (예: '{symbol_slug}_{ltf_slug}')",
     )
     parser.add_argument("--storage-url", type=str, help="Override Optuna storage URL (sqlite:/// or RDB)")
     parser.add_argument(
@@ -3281,7 +3246,6 @@ def _execute_single(
     params_cfg.setdefault("space", {})
     backtest_cfg.setdefault("symbols", backtest_cfg.get("symbols", []))
     backtest_cfg.setdefault("timeframes", backtest_cfg.get("timeframes", []))
-    backtest_cfg.setdefault("htf_timeframes", backtest_cfg.get("htf_timeframes", []))
 
     cli_tokens = list(argv or [])
 
@@ -3295,9 +3259,7 @@ def _execute_single(
 
     batch_ctx = getattr(args, "_batch_context", None)
     if batch_ctx:
-        suffix = batch_ctx.get("suffix") or (
-            f"{batch_ctx.get('ltf_slug', '')}_{batch_ctx.get('htf_slug', '')}".strip("_")
-        )
+        suffix = batch_ctx.get("suffix") or batch_ctx.get("ltf_slug") or ""
         try:
             args.run_tag = _format_batch_value(
                 batch_ctx.get("run_tag_template"),
@@ -3388,23 +3350,9 @@ def _execute_single(
 
     symbol_choices = list(dict.fromkeys(backtest_cfg.get("symbols") or ([params_cfg.get("symbol")] if params_cfg.get("symbol") else [])))
 
-    def _collect_htfs(cfg: Dict[str, object]) -> List[str]:
-        values: List[str] = []
-        raw = cfg.get("htf_timeframes")
-        if isinstance(raw, (list, tuple)):
-            values.extend(str(item) for item in raw if item)
-        single = cfg.get("htf_timeframe")
-        if single:
-            values.append(str(single))
-        return values
-
-    htf_choices = list(dict.fromkeys(_collect_htfs(backtest_cfg) or _collect_htfs(params_cfg)))
-
     selected_symbol = args.symbol or params_cfg.get("symbol") or (symbol_choices[0] if symbol_choices else None)
     selected_timeframe: Optional[str] = args.timeframe
-    selected_htf: Optional[str] = args.htf if args.htf else None
     timeframe_overridden = args.timeframe is not None
-    htf_overridden = args.htf is not None
     all_timeframes_requested = False
 
     if (
@@ -3431,14 +3379,9 @@ def _execute_single(
         params_cfg["timeframe"] = selected_timeframe
         backtest_cfg["timeframes"] = [selected_timeframe]
         _apply_ltf_override_to_datasets(backtest_cfg, selected_timeframe)
-    if htf_overridden and selected_htf is not None:
-        params_cfg["htf_timeframes"] = [selected_htf]
-        backtest_cfg["htf_timeframes"] = [selected_htf]
-    elif htf_choices:
-        params_cfg["htf_timeframes"] = htf_choices
-        backtest_cfg["htf_timeframes"] = htf_choices
-    params_cfg.pop("htf_timeframe", None)
-    backtest_cfg.pop("htf_timeframe", None)
+    for key in ("htf", "htf_timeframe", "htf_timeframes"):
+        params_cfg.pop(key, None)
+        backtest_cfg.pop(key, None)
 
     backtest_periods = backtest_cfg.get("periods") or []
     params_backtest = _ensure_dict(params_cfg, "backtest")
@@ -4113,21 +4056,20 @@ def execute(args: argparse.Namespace, argv: Optional[Sequence[str]] = None) -> N
     symbol_text = str(base_symbol) if base_symbol else "study"
     symbol_slug = _slugify_symbol(symbol_text)
     total = len(combos)
-    combo_summary = ", ".join(f"{ltf}/{htf or '-'}" for ltf, htf in combos)
+    combo_summary = ", ".join(combos)
     LOGGER.info("타임프레임 그리드 %d건 실행: %s", total, combo_summary)
 
-    for index, (ltf, htf) in enumerate(combos, start=1):
+    for index, ltf in enumerate(combos, start=1):
         batch_args = argparse.Namespace(**vars(args))
         batch_args.timeframe = ltf
-        batch_args.htf = htf
-        suffix = f"{_slugify_timeframe(ltf)}_{_slugify_timeframe(htf)}".strip("_")
+        suffix = _slugify_timeframe(ltf)
         context = {
             "index": index,
             "total": total,
             "ltf": ltf,
-            "htf": htf,
+            "htf": None,
             "ltf_slug": _slugify_timeframe(ltf),
-            "htf_slug": _slugify_timeframe(htf),
+            "htf_slug": "",
             "symbol": symbol_text,
             "symbol_slug": symbol_slug,
             "suffix": suffix,
@@ -4138,11 +4080,10 @@ def execute(args: argparse.Namespace, argv: Optional[Sequence[str]] = None) -> N
         }
         batch_args._batch_context = context  # type: ignore[attr-defined]
         LOGGER.info(
-            "(%d/%d) LTF=%s, HTF=%s 조합 최적화 시작",
+            "(%d/%d) LTF=%s 조합 최적화 시작",
             index,
             total,
             ltf,
-            htf or "없음",
         )
         _execute_single(batch_args, params_cfg, backtest_cfg, argv)
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -113,8 +113,8 @@ def test_generate_reports_emits_timeframe_summary(tmp_path: Path) -> None:
     osc_idx = results_df.columns.get_loc("oscLen")
     stat_idx = results_df.columns.get_loc("statThreshold")
     assert osc_idx < stat_idx
-    assert {"timeframe", "htf_timeframe"}.issubset(summary_df.columns)
+    assert "timeframe" in summary_df.columns
+    assert "htf_timeframe" not in summary_df.columns
     assert (summary_df["timeframe"] == "1m").any()
     assert "Sortino_mean" in ranking_df.columns
-    assert (summary_df["htf_timeframe"] == "None").any()
-    assert (ranking_df["htf_timeframe"] == "None").any()
+    assert "htf_timeframe" not in ranking_df.columns


### PR DESCRIPTION
## 요약
- HTF 기능을 전역 비활성화하고 LTF 전용 데이터셋/배치 로직으로 단순화했습니다.
- 리포트/지표 출력에서 HTF 관련 컬럼을 제거하고 손실 없는 구간은 ProfitFactor=0과 별도 플래그로 기록하도록 조정했습니다.
- 문서와 테스트를 LTF 전용 워크플로에 맞게 갱신했습니다.

## 테스트
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e48c4f60a4832082496c4fb07019ef