### PR TITLE
LTF 전용 백테스트 문서 정리

### DIFF
--- a/#Uc2e4#Ud589-#Uac00#Uc774#Ub4dc-Optuna-#Ubc31#Ud14c#Uc2a4#Ud2b8-#Uc124#Uba85#Uc11c.txt
+++ b/#Uc2e4#Ud589-#Uac00#Uc774#Ub4dc-Optuna-#Ubc31#Ud14c#Uc2a4#Ud2b8-#Uc124#Uba85#Uc11c.txt
@@ -89,7 +89,7 @@ $env:MKL_NUM_THREADS="1"
 $env:OPENBLAS_NUM_THREADS="1"
 $env:NUMEXPR_NUM_THREADS="1"
 
-2) 기본 실행 예시 (ETHUSDT / 1m vs HTF=5m)
+2) 기본 실행 예시 (ETHUSDT / 1m 단일 LTF)
 # 파라미터 탐색 범위는 params.yaml에 정의됨
 # --no-simple-metrics 권장(비정상 스코어 방지 가드 경로 사용)
 python -m optimize.run --pick-top50 1 `
@@ -135,10 +135,12 @@ python -m optimize.run --pick-top50 1 `
   인사이트 텍스트는 `reports/<timestamp>/logs/gemini_insights.md` 파일과 로그에서 확인할 수 있습니다.
 
 7) 리포트/로그 디렉터리 안내
-- 출력 경로: reports\<UTC_날짜-시간>_<심볼>_<tf>_<htf>\...
-  예) reports\20251002-1206_ETHUSDT_1m_5m\trials\trials.jsonl
+- 출력 경로: reports\<UTC_날짜-시간>_<심볼>_<ltf>\...
+  예) reports\20251002-1206_ETHUSDT_1m\trials\trials.jsonl
+- 현재 기본 프로필은 LTF 단일 조합만 생성하므로 폴더명에 HTF 구간이 포함되지 않습니다.
+- 상위봉 필터 테스트가 필요하면 params.yaml에서 별도 overrides를 만들어 개별 LTF용 실행을 분리하세요.
 - (패치 전 임시 해결) 경로가 없어서 에러 날 때는 먼저 폴더를 생성:
-  New-Item -ItemType Directory -Force -Path "reports\20251002-1206_ETHUSDT_1m_5m\trials"
+  New-Item -ItemType Directory -Force -Path "reports\20251002-1206_ETHUSDT_1m\trials"
 
 8) 자주 발생하는 오류와 해결
 A. FileNotFoundError / OSError: reports\...\trials 가 없다고 나옴
@@ -212,7 +214,7 @@ $env:MKL_NUM_THREADS="1"
 $env:OPENBLAS_NUM_THREADS="1"
 $env:NUMEXPR_NUM_THREADS="1"
 
-2) 기본 실행 예시 (ETHUSDT / 1m vs HTF=5m)
+2) 기본 실행 예시 (ETHUSDT / 1m 단일 LTF)
 # 파라미터 탐색 범위는 params.yaml에 정의됨
 # --no-simple-metrics 권장(비정상 스코어 방지 가드 경로 사용)
 python -m optimize.run --pick-top50 1 `
@@ -258,10 +260,12 @@ python -m optimize.run --pick-top50 1 `
   인사이트 텍스트는 `reports/<timestamp>/logs/gemini_insights.md` 파일과 로그에서 확인할 수 있습니다.
 
 7) 리포트/로그 디렉터리 안내
-- 출력 경로: reports\<UTC_날짜-시간>_<심볼>_<tf>_<htf>\...
-  예) reports\20251002-1206_ETHUSDT_1m_5m\trials\trials.jsonl
+- 출력 경로: reports\<UTC_날짜-시간>_<심볼>_<ltf>\...
+  예) reports\20251002-1206_ETHUSDT_1m\trials\trials.jsonl
+- 현재 기본 프로필은 LTF 단일 조합만 생성하므로 폴더명에 HTF 구간이 포함되지 않습니다.
+- 상위봉 필터 테스트가 필요하면 params.yaml에서 별도 overrides를 만들어 개별 LTF용 실행을 분리하세요.
 - (패치 전 임시 해결) 경로가 없어서 에러 날 때는 먼저 폴더를 생성:
-  New-Item -ItemType Directory -Force -Path "reports\20251002-1206_ETHUSDT_1m_5m\trials"
+  New-Item -ItemType Directory -Force -Path "reports\20251002-1206_ETHUSDT_1m\trials"
 
 8) 자주 발생하는 오류와 해결
 A. FileNotFoundError / OSError: reports\...\trials 가 없다고 나옴

--- a/config/backtest.yaml
+++ b/config/backtest.yaml
@@ -8,7 +8,8 @@ data:
 
 datasets:
   - ltf: [1m, 3m, 5m]
-    htf: [5m, 15m, 60m]
+    # HTF 조합은 1차 백테스트에서 사용하지 않도록 제거했습니다.
+    # 상위봉 필터가 필요한 경우 params.yaml > overrides 에서 별도 LTF 프로필을 생성하세요.
     start: 2024-01-01
     end:   2025-09-26
 

--- a/실행-가이드-Optuna-백테스트-설명서.txt
+++ b/실행-가이드-Optuna-백테스트-설명서.txt
@@ -89,7 +89,7 @@ $env:MKL_NUM_THREADS="1"
 $env:OPENBLAS_NUM_THREADS="1"
 $env:NUMEXPR_NUM_THREADS="1"
 
-2) 기본 실행 예시 (ETHUSDT / 1m vs HTF=5m)
+2) 기본 실행 예시 (ETHUSDT / 1m 단일 LTF)
 # 파라미터 탐색 범위는 params.yaml에 정의됨
 # --no-simple-metrics 권장(비정상 스코어 방지 가드 경로 사용)
 python -m optimize.run --pick-top50 1 `
@@ -135,10 +135,12 @@ python -m optimize.run --pick-top50 1 `
   인사이트 텍스트는 `reports/<timestamp>/logs/gemini_insights.md` 파일과 로그에서 확인할 수 있습니다.
 
 7) 리포트/로그 디렉터리 안내
-- 출력 경로: reports\<UTC_날짜-시간>_<심볼>_<tf>_<htf>\...
-  예) reports\20251002-1206_ETHUSDT_1m_5m\trials\trials.jsonl
+- 출력 경로: reports\<UTC_날짜-시간>_<심볼>_<ltf>\...
+  예) reports\20251002-1206_ETHUSDT_1m\trials\trials.jsonl
+- 현재 기본 프로필은 LTF 단일 조합만 생성하므로 폴더명에 HTF 구간이 포함되지 않습니다.
+- 상위봉 필터 테스트가 필요하면 params.yaml에서 별도 overrides를 만들어 개별 LTF용 실행을 분리하세요.
 - (패치 전 임시 해결) 경로가 없어서 에러 날 때는 먼저 폴더를 생성:
-  New-Item -ItemType Directory -Force -Path "reports\20251002-1206_ETHUSDT_1m_5m\trials"
+  New-Item -ItemType Directory -Force -Path "reports\20251002-1206_ETHUSDT_1m\trials"
 
 8) 자주 발생하는 오류와 해결
 A. FileNotFoundError / OSError: reports\...\trials 가 없다고 나옴
@@ -212,7 +214,7 @@ $env:MKL_NUM_THREADS="1"
 $env:OPENBLAS_NUM_THREADS="1"
 $env:NUMEXPR_NUM_THREADS="1"
 
-2) 기본 실행 예시 (ETHUSDT / 1m vs HTF=5m)
+2) 기본 실행 예시 (ETHUSDT / 1m 단일 LTF)
 # 파라미터 탐색 범위는 params.yaml에 정의됨
 # --no-simple-metrics 권장(비정상 스코어 방지 가드 경로 사용)
 python -m optimize.run --pick-top50 1 `
@@ -258,10 +260,12 @@ python -m optimize.run --pick-top50 1 `
   인사이트 텍스트는 `reports/<timestamp>/logs/gemini_insights.md` 파일과 로그에서 확인할 수 있습니다.
 
 7) 리포트/로그 디렉터리 안내
-- 출력 경로: reports\<UTC_날짜-시간>_<심볼>_<tf>_<htf>\...
-  예) reports\20251002-1206_ETHUSDT_1m_5m\trials\trials.jsonl
+- 출력 경로: reports\<UTC_날짜-시간>_<심볼>_<ltf>\...
+  예) reports\20251002-1206_ETHUSDT_1m\trials\trials.jsonl
+- 현재 기본 프로필은 LTF 단일 조합만 생성하므로 폴더명에 HTF 구간이 포함되지 않습니다.
+- 상위봉 필터 테스트가 필요하면 params.yaml에서 별도 overrides를 만들어 개별 LTF용 실행을 분리하세요.
 - (패치 전 임시 해결) 경로가 없어서 에러 날 때는 먼저 폴더를 생성:
-  New-Item -ItemType Directory -Force -Path "reports\20251002-1206_ETHUSDT_1m_5m\trials"
+  New-Item -ItemType Directory -Force -Path "reports\20251002-1206_ETHUSDT_1m\trials"
 
 8) 자주 발생하는 오류와 해결
 A. FileNotFoundError / OSError: reports\...\trials 가 없다고 나옴


### PR DESCRIPTION
## 요약
- config/backtest.yaml에서 HTF 조합을 제거하고 LTF 단일 운용을 위한 안내 주석을 추가했습니다.
- Optuna 실행 가이드 문서의 실행 예시와 리포트 경로 설명을 LTF 전용 흐름에 맞춰 수정했습니다.

## 테스트
- 해당 사항 없음

------
https://chatgpt.com/codex/tasks/task_e_68e4996d6e1c832089ccad4f22bd3e96