### PR TITLE
대체 엔진 지표/로그 보정 및 워크포워드 병렬화

### DIFF
--- a/optimize/alternative_engine.py
+++ b/optimize/alternative_engine.py
@@ -824,7 +824,10 @@ def _vectorbt_backtest(
         raw_returns = raw_returns_attr()
     else:
         raw_returns = raw_returns_attr
-    returns = pd.Series(np.asarray(raw_returns), index=parsed.df.index)
+    returns = pd.Series(
+        np.asarray(raw_returns, dtype=float), index=parsed.df.index, dtype=float
+    )
+    returns.name = "returns"
 
     records = pf.trades.records_readable
     trades: List[Trade] = []
@@ -860,6 +863,8 @@ def _vectorbt_backtest(
             trades.append(trade)
 
     metrics = aggregate_metrics(trades, returns, simple=False)
+    metrics["TradesList"] = trades
+    metrics["Returns"] = returns
     metrics.setdefault("InitialCapital", parsed.initial_capital)
     metrics.setdefault("Leverage", parsed.leverage)
     metrics.setdefault("Commission", parsed.commission_pct)

--- a/optimize/run.py
+++ b/optimize/run.py
@@ -2672,12 +2672,15 @@ def optimisation_loop(
 
             # Extract metrics for the trial.  Sortino and ProfitFactor are
             # explicitly captured to support ordered CSV logging.
-            sortino_val = _metric_value("Sortino") or trial.user_attrs.get("sortino")
-            pf_val = _metric_value("ProfitFactor") or trial.user_attrs.get("profit_factor")
-            lossless_pf_val = (
-                _metric_value("LosslessProfitFactorValue")
-                or trial.user_attrs.get("lossless_profit_factor_value")
-            )
+            sortino_val = _metric_value("Sortino")
+            if sortino_val is None:
+                sortino_val = trial.user_attrs.get("sortino")
+            pf_val = _metric_value("ProfitFactor")
+            if pf_val is None:
+                pf_val = trial.user_attrs.get("profit_factor")
+            lossless_pf_val = _metric_value("LosslessProfitFactorValue")
+            if lossless_pf_val is None:
+                lossless_pf_val = trial.user_attrs.get("lossless_profit_factor_value")
 
             row = {
                 "number": trial.number,
@@ -2719,8 +2722,17 @@ def optimisation_loop(
             )
             total_display: object = n_trials if n_trials else len(trials_snapshot)
             # Display Sortino and ProfitFactor for progress logs in order of importance
-            sortino_display = row.get("sortino") or trial.user_attrs.get("sortino") or "-"
-            pf_display = row.get("profit_factor") or trial.user_attrs.get("profit_factor") or "-"
+            sortino_display = row.get("sortino")
+            if sortino_display in {None, ""}:
+                sortino_display = trial.user_attrs.get("sortino")
+            if sortino_display in {None, ""}:
+                sortino_display = "-"
+
+            pf_display = row.get("profit_factor")
+            if pf_display in {None, ""}:
+                pf_display = trial.user_attrs.get("profit_factor")
+            if pf_display in {None, ""}:
+                pf_display = "-"
             if (
                 isinstance(pf_display, str)
                 and pf_display.strip().lower() == "overfactor"

--- a/optimize/wf.py
+++ b/optimize/wf.py
@@ -1,8 +1,9 @@
 """Walk-forward analysis utilities."""
 from __future__ import annotations
 
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -16,6 +17,35 @@ def _clean_metrics(metrics: Dict[str, object]) -> Dict[str, float]:
         if isinstance(value, (int, float, bool)):
             clean[key] = float(value)
     return clean
+
+
+def _run_walk_forward_segment(
+    train_df: pd.DataFrame,
+    test_df: pd.DataFrame,
+    train_htf: Optional[pd.DataFrame],
+    test_htf: Optional[pd.DataFrame],
+    params: Dict[str, float | bool],
+    fees: Dict[str, float],
+    risk: Dict[str, float],
+    min_trades: Optional[int],
+) -> Tuple[Dict[str, float], Dict[str, float]]:
+    train_metrics = run_backtest(
+        train_df,
+        params,
+        fees,
+        risk,
+        htf_df=train_htf,
+        min_trades=min_trades,
+    )
+    test_metrics = run_backtest(
+        test_df,
+        params,
+        fees,
+        risk,
+        htf_df=test_htf,
+        min_trades=min_trades,
+    )
+    return _clean_metrics(train_metrics), _clean_metrics(test_metrics)
 
 
 @dataclass
@@ -38,6 +68,9 @@ def run_walk_forward(
     step: int,
     htf_df: Optional[pd.DataFrame] = None,
     min_trades: Optional[int] = None,
+    *,
+    n_jobs: int = 1,
+    executor: str = "process",
 ) -> Dict[str, object]:
     segments: List[SegmentResult] = []
     total = len(df)
@@ -70,6 +103,15 @@ def run_walk_forward(
         }
 
     start = 0
+    segment_inputs: List[
+        Tuple[
+            pd.DataFrame,
+            pd.DataFrame,
+            Optional[pd.DataFrame],
+            Optional[pd.DataFrame],
+        ]
+    ] = []
+    boundaries: List[Tuple[pd.Timestamp, pd.Timestamp, pd.Timestamp, pd.Timestamp]] = []
 
     while start + train_bars + test_bars <= total:
         train_slice = slice(start, start + train_bars)
@@ -83,34 +125,85 @@ def run_walk_forward(
         train_htf = htf_df.loc[: train_df.index[-1]] if htf_df is not None else None
         test_htf = htf_df.loc[: test_df.index[-1]] if htf_df is not None else None
 
-        train_metrics = run_backtest(
-            train_df,
-            params,
-            fees,
-            risk,
-            htf_df=train_htf,
-            min_trades=min_trades,
-        )
-        test_metrics = run_backtest(
-            test_df,
-            params,
-            fees,
-            risk,
-            htf_df=test_htf,
-            min_trades=min_trades,
-        )
-
-        segments.append(
-            SegmentResult(
-                train_metrics=_clean_metrics(train_metrics),
-                test_metrics=_clean_metrics(test_metrics),
-                train_start=train_df.index[0],
-                train_end=train_df.index[-1],
-                test_start=test_df.index[0],
-                test_end=test_df.index[-1],
-            )
+        segment_inputs.append((train_df, test_df, train_htf, test_htf))
+        boundaries.append(
+            (train_df.index[0], train_df.index[-1], test_df.index[0], test_df.index[-1])
         )
         start += step
+
+    if not segment_inputs:
+        summary = {
+            "segments": segments,
+            "oos_mean": 0.0,
+            "oos_median": 0.0,
+            "count": 0,
+        }
+        return summary
+
+    jobs = max(1, int(n_jobs))
+    executor_choice = executor.lower().strip()
+    parallel_enabled = jobs > 1 and len(segment_inputs) > 1
+
+    results: List[Optional[Tuple[Dict[str, float], Dict[str, float]]]] = [
+        None
+        for _ in segment_inputs
+    ]
+
+    if parallel_enabled:
+        if executor_choice == "thread":
+            pool_cls = ThreadPoolExecutor
+        else:
+            pool_cls = ProcessPoolExecutor
+        with pool_cls(max_workers=jobs) as pool:
+            futures = {
+                pool.submit(
+                    _run_walk_forward_segment,
+                    segment_inputs[idx][0],
+                    segment_inputs[idx][1],
+                    segment_inputs[idx][2],
+                    segment_inputs[idx][3],
+                    params,
+                    fees,
+                    risk,
+                    min_trades,
+                ): idx
+                for idx in range(len(segment_inputs))
+            }
+            for future in as_completed(futures):
+                idx = futures[future]
+                train_metrics, test_metrics = future.result()
+                results[idx] = (train_metrics, test_metrics)
+    else:
+        for idx, (train_df_seg, test_df_seg, train_htf_seg, test_htf_seg) in enumerate(
+            segment_inputs
+        ):
+            train_metrics, test_metrics = _run_walk_forward_segment(
+                train_df_seg,
+                test_df_seg,
+                train_htf_seg,
+                test_htf_seg,
+                params,
+                fees,
+                risk,
+                min_trades,
+            )
+            results[idx] = (train_metrics, test_metrics)
+
+    for idx, boundary in enumerate(boundaries):
+        result_pair = results[idx]
+        if result_pair is None:
+            continue
+        train_metrics, test_metrics = result_pair
+        segments.append(
+            SegmentResult(
+                train_metrics=train_metrics,
+                test_metrics=test_metrics,
+                train_start=boundary[0],
+                train_end=boundary[1],
+                test_start=boundary[2],
+                test_end=boundary[3],
+            )
+        )
 
     oos_returns = [seg.test_metrics.get("NetProfit", 0.0) for seg in segments if seg.test_metrics.get("Valid", True)]
     oos_series = pd.Series(oos_returns) if oos_returns else pd.Series(dtype=float)

--- a/tests/test_alternative_engine.py
+++ b/tests/test_alternative_engine.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+import numpy as np
+import pandas as pd
+from optimize import alternative_engine as alt
+from optimize.run import combine_metrics
+
+
+class DummyRecords:
+    def __init__(self, records: List[Dict[str, object]]):
+        self.records_readable = pd.DataFrame(records)
+
+
+class DummyTrades:
+    def __init__(self, records: List[Dict[str, object]]):
+        self.records_readable = pd.DataFrame(records)
+
+
+class DummyPortfolio:
+    def __init__(self, close_series: pd.Series, returns: np.ndarray, records: List[Dict[str, object]]):
+        self._close = close_series
+        self._returns = returns
+        self.trades = DummyTrades(records)
+
+    @property
+    def close(self) -> pd.Series:
+        return self._close
+
+    @property
+    def returns(self) -> np.ndarray:
+        return self._returns
+
+    @staticmethod
+    def from_signals(
+        close: pd.Series,
+        entries: np.ndarray,
+        exits: np.ndarray,
+        short_entries: np.ndarray,
+        short_exits: np.ndarray,
+        fees: float,
+        size: float,
+        size_type: str,
+        upon_opposite_entry: str,
+    ) -> "DummyPortfolio":
+        returns = np.array([0.02, -0.01, 0.03], dtype=float)
+        records = [
+            {
+                "Entry Timestamp": close.index[0],
+                "Exit Timestamp": close.index[1],
+                "Direction": "Long",
+                "Size": size,
+                "Avg Entry Price": float(close.iloc[0]),
+                "Avg Exit Price": float(close.iloc[1]),
+                "PnL": 10.0,
+                "Return": 0.1,
+            }
+        ]
+        return DummyPortfolio(close, returns, records)
+
+
+def test_vectorbt_backtest_returns_trades_and_returns(monkeypatch):
+    index = pd.date_range("2024-01-01", periods=3, freq="1h", tz="UTC")
+    df = pd.DataFrame(
+        {
+            "open": [100.0, 101.0, 102.0],
+            "high": [101.0, 102.0, 103.0],
+            "low": [99.0, 100.0, 101.0],
+            "close": [100.5, 101.5, 102.5],
+            "volume": [1.0, 1.0, 1.0],
+        },
+        index=index,
+    )
+
+    parsed = alt._ParsedInputs(
+        df=df,
+        htf_df=None,
+        start_ts=index[0],
+        commission_pct=0.0005,
+        slippage_ticks=0.0,
+        leverage=1.0,
+        initial_capital=1000.0,
+        capital_pct=1.0,
+        allow_long=True,
+        allow_short=False,
+        require_cross=False,
+        exit_opposite=False,
+        min_trades=0,
+        min_hold_bars=0,
+        max_consecutive_losses=10,
+    )
+
+    def fake_validate(params: Dict[str, object]) -> None:
+        return None
+
+    def fake_signals(df: pd.DataFrame, params: Dict[str, object], parsed_inputs: alt._ParsedInputs) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        entries = np.array([True, False, False])
+        exits = np.array([False, True, False])
+        shorts = np.zeros_like(entries, dtype=bool)
+        return entries, exits, shorts, shorts
+
+    def fake_apply(parsed_inputs, params, long_entries, long_exits, short_entries, short_exits):
+        return long_entries, long_exits, short_entries, short_exits
+
+    monkeypatch.setattr(alt, "_validate_feature_flags", fake_validate)
+    monkeypatch.setattr(alt, "_build_signals", fake_signals)
+    monkeypatch.setattr(alt, "_apply_exit_overrides", fake_apply)
+    monkeypatch.setattr(alt, "VECTORBT_AVAILABLE", True)
+    monkeypatch.setattr(alt, "_VBT_MODULE", type("DummyModule", (), {"Portfolio": DummyPortfolio}))
+
+    metrics = alt._vectorbt_backtest(parsed, params={})
+
+    assert "TradesList" in metrics
+    assert "Returns" in metrics
+    assert isinstance(metrics["TradesList"], list)
+    assert isinstance(metrics["Returns"], pd.Series)
+    assert len(metrics["Returns"]) == len(df)
+
+    combined = combine_metrics([metrics])
+    assert combined["Trades"] == len(metrics["TradesList"])
+    assert combined["NetProfit"] != 0.0

--- a/tests/test_strategy_model.py
+++ b/tests/test_strategy_model.py
@@ -1,5 +1,7 @@
 import math
 
+import numpy as np
+
 import pandas as pd
 import pytest
 
@@ -259,3 +261,17 @@ def test_volatility_guard_atr_matches_reference():
             expected.append(0.0)
 
     assert computed == pytest.approx(expected)
+
+
+def test_rolling_rma_last_matches_recursive_formula():
+    values = np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype=float)
+
+    result = _rolling_rma_last(values, 3)
+
+    assert np.isnan(result[0])
+    assert np.isnan(result[1])
+    expected_tail = [2.0, 2.6666666667, 3.4444444444]
+    assert result[2:] == pytest.approx(expected_tail)
+
+    zero_length = _rolling_rma_last(values, 0)
+    assert np.isnan(zero_length).all()

--- a/tests/test_walk_forward.py
+++ b/tests/test_walk_forward.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from optimize.wf import run_walk_forward
+
+
+def _build_frame() -> pd.DataFrame:
+    index = pd.date_range("2024-05-01", periods=12, freq="1h", tz="UTC")
+    base = pd.Series(range(len(index)), index=index, dtype=float)
+    return pd.DataFrame(
+        {
+            "open": base + 0.1,
+            "high": base + 0.2,
+            "low": base - 0.1,
+            "close": base,
+            "volume": 1.0,
+        }
+    )
+
+
+def test_walk_forward_parallel_matches_serial(monkeypatch):
+    df = _build_frame()
+
+    def fake_run_backtest(data, params, fees, risk, htf_df=None, min_trades=None):
+        return {"NetProfit": float(data["close"].sum()), "Valid": True}
+
+    monkeypatch.setattr("optimize.wf.run_backtest", fake_run_backtest)
+
+    params = {}
+    fees = {}
+    risk = {}
+
+    serial = run_walk_forward(
+        df,
+        params,
+        fees,
+        risk,
+        train_bars=4,
+        test_bars=2,
+        step=2,
+        n_jobs=1,
+    )
+
+    parallel = run_walk_forward(
+        df,
+        params,
+        fees,
+        risk,
+        train_bars=4,
+        test_bars=2,
+        step=2,
+        n_jobs=2,
+        executor="thread",
+    )
+
+    assert parallel["count"] == serial["count"]
+    assert len(parallel["segments"]) == len(serial["segments"])
+    assert parallel["oos_mean"] == pytest.approx(serial["oos_mean"])
+    assert parallel["oos_median"] == pytest.approx(serial["oos_median"])
+
+    for left, right in zip(serial["segments"], parallel["segments"]):
+        assert left.train_start == right.train_start
+        assert left.test_end == right.test_end
+        assert left.train_metrics == right.train_metrics
+        assert left.test_metrics == right.test_metrics


### PR DESCRIPTION
## Summary
- vectorbt 대체 엔진 결과에 수익률 시리즈와 트레이드 리스트를 포함해 결합 지표 계산 시 누락되는 항목을 복구했습니다.
- 옵티마 진행 로그에서 Sortino/ProfitFactor가 0일 때도 그대로 기록·표시되도록 보정하고 회귀 테스트를 추가했습니다.
- RMA 보조 함수와 워크포워드 실행을 단일 순회/병렬 실행 구조로 재작성하고 대응 테스트를 보강했습니다.

## Testing
- `pytest tests/test_alternative_engine.py tests/test_run_helpers.py::test_log_trial_preserves_zero_metrics tests/test_strategy_model.py::test_rolling_rma_last_matches_recursive_formula tests/test_walk_forward.py`


------
https://chatgpt.com/codex/tasks/task_e_68e67fe75a6083208ed210b3e4642280