### PR TITLE
제미니 기본 모델 갱신 및 폴백 로직 검증 강화

### DIFF
--- a/config/params.yaml
+++ b/config/params.yaml
@@ -49,6 +49,7 @@ objective:
   - name: MaxDD
     goal: minimize  # MaxDD는 낮을수록 좋으니까 'minimize'로 설정
     weight: 0.7     # 이 가중치가 높을수록 DD가 낮은 안정적인 전략을 더 선호하게 돼
+                    # (Trades 등 다른 가중치와의 상대값으로 균형이 결정되므로 동시에 조정 가능)
   # --- 토글 끝 ---
 constraints:
   min_trades_test: 50   # 최소 거래 수. 거래수가 50 미만이면 학습 점수에 반영하지 않습니다.
@@ -127,7 +128,11 @@ llm:
   api_key_env: GEMINI_API_KEY
   # api_key: "..."               # 직접 입력 (권장 X)
   # api_key_file: ~/.secrets/gemini.key
-  model: gemini-flash-latest
+  model: gemini-2.5-pro
+  fallback_models:
+    - gemini-2.5-flash
+    - gemini-2.0-flash
+    - gemini-1.5-flash
   top_n: 10
   count: 8
   initial_trials: 20

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -90,7 +90,8 @@ def test_generate_llm_candidates_switches_model_on_permission_error(monkeypatch)
 
         def generate_content(self, **kwargs):
             self.calls.append(kwargs)
-            if kwargs.get("model") == "gemini-2.5-flash":
+            model_name = kwargs.get("model")
+            if model_name in {"gemini-2.5-pro", "gemini-2.5-flash"}:
                 raise RuntimeError("PERMISSION_DENIED: model not available")
             return DummyResponse()
 
@@ -108,8 +109,8 @@ def test_generate_llm_candidates_switches_model_on_permission_error(monkeypatch)
     config = {
         "enabled": True,
         "api_key": "dummy",
-        "model": "gemini-2.5-flash",
-        "fallback_models": ["gemini-2.0-flash"],
+        "model": "gemini-2.5-pro",
+        "fallback_models": ["gemini-2.5-flash"],
         "count": 1,
         "top_n": 1,
     }
@@ -117,6 +118,7 @@ def test_generate_llm_candidates_switches_model_on_permission_error(monkeypatch)
     suggestions: LLMSuggestions = generate_llm_candidates(space, [trial], config)
 
     assert suggestions.candidates == [{"x": 1}]
-    assert len(dummy_models.calls) == 2
-    assert dummy_models.calls[0]["model"] == "gemini-2.5-flash"
-    assert dummy_models.calls[1]["model"] == "gemini-2.0-flash"
+    assert len(dummy_models.calls) == 3
+    assert dummy_models.calls[0]["model"] == "gemini-2.5-pro"
+    assert dummy_models.calls[1]["model"] == "gemini-2.5-flash"
+    assert dummy_models.calls[2]["model"] == "gemini-2.0-flash"


### PR DESCRIPTION
## 요약
- Optuna 파라미터 프로필의 LLM 설정을 gemini-2.5-pro 기본 및 플래시 계열 폴백 목록으로 정리하고 MaxDD 가중치 주석을 보강했습니다.
- Gemini 폴백 순서를 검증하는 단위 테스트를 최신 모델 우선순위에 맞춰 확장했습니다.

## 테스트
- `pytest tests/test_llm.py`


------
https://chatgpt.com/codex/tasks/task_e_68e9c55cc3d883209d28a26892ca69ec