### PR TITLE
vectorbt 종가 체결 및 메인 엔진 플립플랍 방지

### DIFF
--- a/optimize/alternative_engine.py
+++ b/optimize/alternative_engine.py
@@ -841,6 +841,7 @@ def _vectorbt_backtest(
         fees=parsed.commission_pct,
         size=trade_value,
         size_type="value",
+        execute_on_close=True,
         # rely on vectorbt defaults for direction and opposite entry handling
         upon_opposite_entry="close",
     )

--- a/optimize/strategy_model.py
+++ b/optimize/strategy_model.py
@@ -2690,6 +2690,7 @@ def run_backtest(
                     lowest_since_entry = low_price
                     pos_bars = 0
                     reversal_countdown = int(reversal_delay_sec // 60) if reversal_delay_sec > 0 else 0
+                    continue
             elif enter_short:
                 stop_hint = atr_len_val
                 if use_stop_loss:
@@ -2718,6 +2719,7 @@ def run_backtest(
                     lowest_since_entry = low_price
                     pos_bars = 0
                     reversal_countdown = int(reversal_delay_sec // 60) if reversal_delay_sec > 0 else 0
+                    continue
 
     if position.direction != 0 and position.entry_time is not None:
         close_position(df.index[-1], close_vals[-1], "EndOfData")

--- a/tests/test_alternative_engine.py
+++ b/tests/test_alternative_engine.py
@@ -42,6 +42,7 @@ class DummyPortfolio:
         fees: float,
         size: float,
         size_type: str,
+        execute_on_close: bool,
         upon_opposite_entry: str,
     ) -> "DummyPortfolio":
         returns = np.array([0.02, -0.01, 0.03], dtype=float)


### PR DESCRIPTION
## 요약
- vectorbt 포트폴리오 생성 시 `execute_on_close=True` 옵션을 추가하여 신호가 발생한 봉의 종가로 체결되도록 변경했습니다.
- 메인 엔진에서 포지션 진입 직후에는 바로 다음 봉으로 넘어가도록 `continue`를 추가해 한 봉 내 플립플랍을 차단했습니다.
- 테스트용 더미 포트폴리오 시그니처를 업데이트하여 새로운 옵션과 호환되도록 조정했습니다.

## 테스트
- pytest tests/test_alternative_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68ea0ef5449083209aea8a2ed473a3e6