### PR TITLE
타임프레임 요약 CSV에 실제 LTF 반영

### DIFF
--- a/tests/test_run_helpers.py
+++ b/tests/test_run_helpers.py
@@ -15,6 +15,7 @@ from optimize.run import (
     DatasetSpec,
     optimisation_loop,
     _configure_parallel_workers,
+    _ensure_timeframe_param,
     _apply_study_registry_defaults,
     _clean_metrics,
     _dataset_total_volume,
@@ -144,6 +145,18 @@ def _make_dataset(timeframe: str, htf: Optional[str]) -> DatasetSpec:
         htf_timeframe=htf,
         source_symbol="BINANCE:TESTUSDT",
     )
+
+
+def test_ensure_timeframe_param_infers_choices_when_missing():
+    datasets = [_make_dataset("1m", None), _make_dataset("3m", None)]
+    space: Dict[str, Dict[str, object]] = {}
+    search_cfg = {"diversify": {"timeframe_cycle": [{"timeframe": "1m"}, {"timeframe": "3m"}]}}
+
+    updated, added = _ensure_timeframe_param(space, datasets, search_cfg)
+
+    assert added is True
+    assert "timeframe" in updated
+    assert updated["timeframe"]["values"] == ["1m", "3m"]
 
 
 def test_dataset_total_volume_sums_numeric_values():


### PR DESCRIPTION
## 요약
- 최적화 공간에 누락된 timeframe 파라미터를 자동 주입해 타임프레임 사이클이 정상 반영되도록 수정
- CLI/그리드에서 타임프레임을 강제로 선택할 때 샘플링과 보고서 모두 동일한 LTF를 사용하도록 강제
- 신규 헬퍼에 대한 단위 테스트를 추가해 다양한 타임프레임 조합을 검증

## 테스트
- pytest tests/test_run_helpers.py::test_ensure_timeframe_param_infers_choices_when_missing
- pytest tests/test_diversifier.py

------
https://chatgpt.com/codex/tasks/task_e_68ea1f7874fc8320b091525117fb0b54