### PR TITLE
문자열 파라미터 단일 입력 검증 강화

### DIFF
--- a/config/params.yaml
+++ b/config/params.yaml
@@ -81,6 +81,7 @@ space:
   fluxSmoothLen:  { type: int,   min: 1,   max: 10,  step: 1 }
   useFluxHeikin:  { type: bool }
   useModFlux:     { type: bool }
+  # NOTE: 문자열 파라미터는 단일 값만 허용되며 리스트/튜플 형태 입력은 오류로 처리됩니다.
   momStyle:       { type: choice, values: [KC, AVG, Deluxe, Mod] }
   maType:         { type: choice, values: [SMA, EMA, HMA] }
 

--- a/optimize/alternative_engine.py
+++ b/optimize/alternative_engine.py
@@ -144,6 +144,26 @@ def _coerce_int(value: object, default: int) -> int:
         return int(default)
 
 
+def _coerce_str(value: object, default: str, *, name: str) -> str:
+    """문자열 파라미터를 엄격하게 변환한다."""
+
+    if value is None:
+        return str(default)
+
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return str(default)
+        if len(value) == 1:
+            value = value[0]
+        else:
+            raise TypeError(
+                f"'{name}' 파라미터에 여러 문자열이 전달되었습니다: {value!r}"
+            )
+
+    text = str(value)
+    return text if text else str(default)
+
+
 def _ensure_datetime_index(frame: pd.DataFrame, label: str) -> pd.DataFrame:
     """OHLCV 프레임이 UTC 기반 DatetimeIndex 를 갖도록 강제한다."""
 
@@ -325,8 +345,8 @@ def _compute_indicators(
     else:
         bb_len = max(_coerce_int(params.get("bbLen"), kc_len), 1)
     bb_mult = _coerce_float(params.get("bbMult"), kc_mult)
-    mom_style = str(params.get("momStyle", "KC") or "KC").strip().lower()
-    ma_type = str(params.get("maType", "SMA") or "SMA").strip().lower()
+    mom_style = _coerce_str(params.get("momStyle"), "KC", name="momStyle").strip().lower()
+    ma_type = _coerce_str(params.get("maType"), "SMA", name="maType").strip().lower()
 
     flux_len = max(_coerce_int(params.get("fluxLen"), 14), 1)
     flux_smooth_len = max(_coerce_int(params.get("fluxSmoothLen"), 1), 1)

--- a/optimize/strategy_model.py
+++ b/optimize/strategy_model.py
@@ -1089,9 +1089,27 @@ def run_backtest(
             target[key] = float(max(0.0, resolved))
 
     def str_param(name: str, default: str, *, enabled: bool = True) -> str:
+        """문자열 파라미터를 안전하게 변환한다.
+
+        Pine/Optuna 설정이 잘못 직렬화되면 문자열 입력이 리스트/튜플로
+        들어오는 경우가 있는데, 이때는 첫 번째 요소만 허용하거나 명시적으로
+        오류를 발생시켜 잘못된 설정이 그대로 진행되지 않도록 한다.
+        """
+
         if not enabled:
             return str(default)
+
         value = params.get(name, default)
+        if isinstance(value, (list, tuple)):
+            if not value:
+                value = default
+            elif len(value) == 1:
+                value = value[0]
+            else:
+                raise TypeError(
+                    f"'{name}' 파라미터에 여러 개의 문자열이 전달되었습니다: {value!r}"
+                )
+
         return str(value) if value is not None else str(default)
 
     # Pine 입력 매핑 -----------------------------------------------------------------


### PR DESCRIPTION
## 요약
- 전략 모델의 문자열 파라미터 보조 함수를 보완하여 리스트/튜플 입력 시 안전하게 처리하거나 오류를 발생시키도록 개선했습니다.
- vectorbt 대체 엔진에서도 동일한 문자열 파라미터 강제 로직을 추가했습니다.
- 파라미터 샘플 YAML에 문자열 입력은 단일 값만 허용된다는 주석을 명시했습니다.

## 테스트
- 해당 없음 (수동 검증)

------
https://chatgpt.com/codex/tasks/task_e_68ea3c803dd4832083f11a7f71b4a9c9