### PR TITLE
모멘텀 정규화 ATR 분기 조정

### DIFF
--- a/strategy/strategy.pine
+++ b/strategy/strategy.pine
@@ -440,12 +440,12 @@ momStyle = switch str.lower(momStyleInput)
     'mod' => 'mod'
     => 'kc'
 
-// ✅ [수정됨] 'deluxe' 및 'kc' 스타일에 ATR 정규화 로직 추가하여 모든 스타일의 값을 일관되게 만듦
+// ✅ [2025-02-15] ATR 정규화 조건 재조정: 'avg'와 'mod'만 ATR로 나누고 나머지는 원시 차이값을 사용
 normRaw = switch momStyle
     'avg'    => (close - avgLineAvg) / nz(atrPrimary, 1)
-    'deluxe' => (close - avgLineDeluxe) / nz(atrPrimary, 1)
+    'deluxe' => (close - avgLineDeluxe)
     'mod'    => (close - midline) / nz(atrPrimary, 1)
-    => (close - meanKc) / nz(atrPrimary, 1)
+    => (close - meanKc)
 
 normSeries = nz(normRaw) * 100.0
 momentum = ta.linreg(normSeries, oscLen, 0)


### PR DESCRIPTION
## 요약
- 모멘텀 정규화 스위치에서 'avg'와 'mod' 스타일만 ATR로 나누도록 조정했습니다.
- 'deluxe' 및 기본 스타일은 기준선 차이만 반환해 Python 백테스트 기준과의 일치성을 강화했습니다.

## 테스트
- 해당 사항 없음


------
https://chatgpt.com/codex/tasks/task_e_68ea44b1e2d883208f956a77a16e20a6