### PR TITLE
플럭스 추가 스무딩 반영 및 백테스트 동기화

### DIFF
--- a/strategy/strategy.pine
+++ b/strategy/strategy.pine
@@ -457,7 +457,12 @@ momSignal = switch str.lower(maTypeInput)
 crossUp = ta.crossover(momentum, momSignal)
 crossDown = ta.crossunder(momentum, momSignal)
 
-fluxHist = useModFlux ? modDirectionalFlux(fluxLen, fluxSmoothLen) : directionalFlux(useFluxHeikin, fluxLen, fluxSmoothLen)
+float fluxHist = na
+if useModFlux
+    fluxHist := modDirectionalFlux(fluxLen, fluxSmoothLen)
+else
+    directionalFluxResult = directionalFlux(useFluxHeikin, fluxLen, fluxSmoothLen)
+    fluxHist := fluxSmoothLen > 1 ? ta.sma(directionalFluxResult, fluxSmoothLen) : directionalFluxResult
 
 momFadeSource = (high + low + close) / 3.0
 momFadeBasis = ta.sma(momFadeSource, momFadeBbLen)


### PR DESCRIPTION
## 요약
- 모디파이드 플럭스를 사용하지 않을 때 fluxSmoothLen이 2 이상이면 방향성 플럭스에 2차 스무딩을 적용하도록 TradingView 스크립트를 조정했습니다.
- fluxHist 계산 분기를 명확히 나눠 불필요한 계산을 줄였습니다.
- 방향성 플럭스의 추가 스무딩 결과가 수동 계산과 일치하는지 확인하는 pytest를 추가했습니다.

## 테스트
- pytest tests/test_alternative_engine.py::test_compute_indicators_with_directional_flux_applies_additional_smoothing


------
https://chatgpt.com/codex/tasks/task_e_68ea44b496ac83209a02cfc17e7f0fe0