### PR TITLE
플럭스 Heikin TR 정합성 보강

### DIFF
--- a/strategy/strategy.pine
+++ b/strategy/strategy.pine
@@ -344,9 +344,13 @@ f_htf(tf, indicatorType, len) =>
 directionalFlux(useHa, len, smoothLen) =>
     srcH = useHa ? haHigh : high
     srcL = useHa ? haLow  : low
-    upMove  = math.max(srcH - nz(srcH[1]), 0)
-    dnMove  = math.max(nz(srcL[1]) - srcL, 0)
-    tr      = atrSeries(len)
+    prevH = useHa ? nz(haHigh[1]) : nz(high[1])
+    prevL = useHa ? nz(haLow[1])  : nz(low[1])
+    prevClose = useHa ? haClose[1] : close[1]
+    upMove  = math.max(srcH - prevH, 0)
+    dnMove  = math.max(prevL - srcL, 0)
+    trBase  = math.max(math.max(srcH - srcL, math.abs(srcH - prevClose)), math.abs(srcL - prevClose))
+    tr      = useHa ? ta.rma(trBase, len) : atrSeries(len)
     up      = tr != 0 ? ta.rma(upMove, len) / tr : 0
     dn      = tr != 0 ? ta.rma(dnMove, len) / tr : 0
     denom   = up + dn
@@ -354,14 +358,20 @@ directionalFlux(useHa, len, smoothLen) =>
     core    = ta.rma(ratio, math.max(math.round(len / 2.0), 1)) * 100
     smoothLen > 1 ? ta.sma(core, smoothLen) : core
 
-modDirectionalFlux(len, smoothLen) =>
-    upMove  = math.max(high - nz(high[1]), 0)
-    dnMove  = math.max(nz(low[1]) - low, 0)
+modDirectionalFlux(useHa, len, smoothLen) =>
+    srcH = useHa ? haHigh : high
+    srcL = useHa ? haLow  : low
+    prevH = useHa ? nz(haHigh[1]) : nz(high[1])
+    prevL = useHa ? nz(haLow[1])  : nz(low[1])
+    prevClose = useHa ? haClose[1] : close[1]
+    upMove  = math.max(srcH - prevH, 0)
+    dnMove  = math.max(prevL - srcL, 0)
     plusDM  = upMove > dnMove and upMove > 0 ? upMove : 0
     minusDM = dnMove > upMove and dnMove > 0 ? dnMove : 0
     plusR   = ta.rma(plusDM, len)
     minusR  = ta.rma(minusDM, len)
-    tr      = atrSeries(len)
+    trBase  = math.max(math.max(srcH - srcL, math.abs(srcH - prevClose)), math.abs(srcL - prevClose))
+    tr      = useHa ? ta.rma(trBase, len) : atrSeries(len)
     up      = tr != 0 ? plusR / tr : 0
     dn      = tr != 0 ? minusR / tr : 0
     denom   = up + dn
@@ -457,7 +467,7 @@ momSignal = switch str.lower(maTypeInput)
 crossUp = ta.crossover(momentum, momSignal)
 crossDown = ta.crossunder(momentum, momSignal)
 
-fluxHist = useModFlux ? modDirectionalFlux(fluxLen, fluxSmoothLen) : directionalFlux(useFluxHeikin, fluxLen, fluxSmoothLen)
+fluxHist = useModFlux ? modDirectionalFlux(useFluxHeikin, fluxLen, fluxSmoothLen) : directionalFlux(useFluxHeikin, fluxLen, fluxSmoothLen)
 
 momFadeSource = (high + low + close) / 3.0
 momFadeBasis = ta.sma(momFadeSource, momFadeBbLen)

--- a/tests/test_alternative_engine.py
+++ b/tests/test_alternative_engine.py
@@ -5,6 +5,8 @@ from typing import Dict, List, Tuple
 import numpy as np
 import pandas as pd
 import pandas.testing as pdt
+import pytest
+
 from optimize import alternative_engine as alt
 from optimize.run import combine_metrics
 
@@ -124,7 +126,8 @@ def test_vectorbt_backtest_returns_trades_and_returns(monkeypatch):
     assert combined["NetProfit"] != 0.0
 
 
-def test_compute_indicators_with_mod_flux_matches_manual_calculation():
+@pytest.mark.parametrize("use_heikin", [False, True])
+def test_compute_indicators_with_mod_flux_matches_manual_calculation(use_heikin):
     index = pd.date_range("2024-01-01", periods=50, freq="1h", tz="UTC")
     base = np.linspace(100.0, 110.0, num=len(index))
     df = pd.DataFrame(
@@ -143,7 +146,7 @@ def test_compute_indicators_with_mod_flux_matches_manual_calculation():
         "signalLen": 3,
         "fluxLen": 8,
         "fluxSmoothLen": 3,
-        "useFluxHeikin": False,
+        "useFluxHeikin": use_heikin,
         "useModFlux": True,
         "kcLen": 10,
         "kcMult": 1.0,


### PR DESCRIPTION
## 요약
- directionalFlux와 modDirectionalFlux가 Heikin OHLC 기반으로 TR/ATR을 계산하도록 수정해 Pine/파이썬 일치성을 강화했습니다.
- 두 플럭스 경로가 동일한 Heikin 사용 플래그를 공유하도록 호출부를 정리했습니다.
- Heikin-Ashi 사용 여부별 플럭스 히스토그램 일치성을 검증하는 단위 테스트를 추가했습니다.

## 테스트
- pytest tests/test_strategy_model.py::test_directional_flux_matches_manual_reference tests/test_alternative_engine.py::test_compute_indicators_with_mod_flux_matches_manual_calculation

------
https://chatgpt.com/codex/tasks/task_e_68ea44b4354c832092a1017b91d946e2